### PR TITLE
Rfoxkendo/issue39

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ glob = "0.3.1"
 memmap = "0.6.2"
 dirs = "5.0.0"
 clap = { version = "4.2.7", features = ["derive"] }
+portman_client="0.2.0"
 
 [dependencies.rocket]
 version="0.5.0-rc.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ use rest::{
     rest_parameter, ringversion, sbind, shm, spectrum, unbind, unimplemented, version,
 };
 use sharedmem::binder;
+use std::env;
 use std::sync::Mutex;
 
 // Pull in Rocket features:
@@ -36,6 +37,8 @@ const DEFAULT_SHM_SPECTRUM_MBYTES: usize = 32;
 struct Args {
     #[arg(short, long, default_value_t=DEFAULT_SHM_SPECTRUM_MBYTES)]
     shm_mbytes: usize,
+    #[arg(short, long, default_value_t = 8000)]
+    port: u16,
 }
 
 // This is now the entry point as Rocket has the main
@@ -57,6 +60,11 @@ fn rocket() -> _ {
         binder: Mutex::new(binder),
         processing: Mutex::new(processor),
     };
+
+    // Set the rocket port then fire it off:
+
+    env::set_var("ROCKET_PORT", args.port.to_string());
+
     rocket::build()
         .manage(state)
         .mount(

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod sharedmem;
 mod spectra;
 
 use clap::Parser;
+use portman_client;
 use rest::{
     apply, channel, data_processing, evbunpack, exit, filter, fit, fold, gates, integrate,
     rest_parameter, ringversion, sbind, shm, spectrum, unbind, unimplemented, version,
@@ -39,6 +40,8 @@ struct Args {
     shm_mbytes: usize,
     #[arg(short, long, default_value_t = 8000)]
     port: u16,
+    #[arg(long)]
+    service: Option<String>,
 }
 
 // This is now the entry point as Rocket has the main
@@ -55,15 +58,18 @@ fn rocket() -> _ {
     let processor = processing::ProcessingApi::new(&channel);
     let binder = binder::start_server(&channel, args.shm_mbytes * 1024 * 1024);
 
+    let (port, client) = get_port(&args);
+
     let state = rest::HistogramState {
         state: Mutex::new((jh, channel)),
         binder: Mutex::new(binder),
         processing: Mutex::new(processor),
+        portman_client: client,
     };
 
     // Set the rocket port then fire it off:
 
-    env::set_var("ROCKET_PORT", args.port.to_string());
+    env::set_var("ROCKET_PORT", port.to_string());
 
     rocket::build()
         .manage(state)
@@ -229,4 +235,25 @@ fn rocket() -> _ {
             "/spectcl/ringformat",
             routes![ringversion::ringversion_get, ringversion::ringversion_set],
         )
+}
+///
+/// Gets the port to use for our REST service.
+/// This uses command line argument that have been Parsed into
+/// the Args struct.   Here's how we determine the port to advertise:
+///
+/// * If service is supplied, then port is assumed to be the port manager's
+/// service port and we advertise given the service specified.
+/// * if service is not supplied, then we advertise on the value of the port
+/// field.
+///
+/// The Client is part of what's returned as it must remain alive to
+/// keep the allocation.
+fn get_port(args: &Args) -> (u16, Option<portman_client::Client>) {
+    if args.service.is_some() {
+        let mut client = portman_client::Client::new(args.port);
+        let port = client.get(args.service.as_ref().unwrap());
+        (port.expect("Could not allocate service port"), Some(client))
+    } else {
+        (args.port, None)
+    }
 }

--- a/src/rest/mod.rs
+++ b/src/rest/mod.rs
@@ -56,6 +56,7 @@ use crate::messaging::parameter_messages::ParameterMessageClient;
 use crate::messaging::Request;
 use crate::processing;
 use crate::sharedmem::binder;
+use portman_client;
 use rocket::serde::Serialize;
 use rocket::State;
 use std::sync::{mpsc, Mutex};
@@ -65,6 +66,7 @@ pub struct HistogramState {
     pub state: Mutex<(thread::JoinHandle<()>, mpsc::Sender<Request>)>,
     pub binder: Mutex<(mpsc::Sender<binder::Request>, thread::JoinHandle<()>)>,
     pub processing: Mutex<processing::ProcessingApi>,
+    pub portman_client: Option<portman_client::Client>,
 }
 
 pub type OptionalStringVec = Option<Vec<String>>;


### PR DESCRIPTION
*   If --service is supplied the --port parameter is
 interpreted as the port on which the port allocator is running
 (normally --service=some-unique-name --port=30000 is best).
 *  If --service is not provided then --port is the numeric port on
 which the rustogrammer REST service runs.

 This required:
 *   Adding a port manager client to the REST server state in order to
 ensure it remains alive during the duration of the program.
 *   Adding the service Option<String to the Args struct but now
 allowing short options for it as shm_mbytes already takes -s.
 *  Providing get_port functionin main.rs to untangle whte port to use.

 Note that the default is hardwired port number 8000 which is the
 default Rocket port.;