### PR TITLE
ISsue #77 - Xamine does not see bound spectra:

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustogramer"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Ron Fox fox@frib.msu.edu"]
 description="A generic histogramer intended for nuclear science data from the FRIB"

--- a/src/sharedmem/mod.rs
+++ b/src/sharedmem/mod.rs
@@ -51,7 +51,7 @@ struct SpectrumDimension {
 
 /// A title or label:
 
-type SpectrumTitle = [char; TITLE_LENGTH];
+type SpectrumTitle = [u8; TITLE_LENGTH];
 
 /// Statistics (not used but still present):
 
@@ -454,8 +454,8 @@ impl SharedMemory {
             header.dsp_xy[slot].ychans = 1;
         }
         for (i, c) in name.chars().enumerate() {
-            header.dsp_titles[slot][i] = c;
-            header.dsp_info[slot][i] = c;
+            header.dsp_titles[slot][i] = c as u8;
+            header.dsp_info[slot][i] = c as u8;
         }
         header.dsp_offsets[slot] = (offset / mem::size_of::<u32>()) as u32;
         header.dsp_types[slot] = spectrum_type;
@@ -470,8 +470,8 @@ impl SharedMemory {
         }
         //Empty  axis titles:
 
-        header.dsp_map[slot].xlabel[0] = '\0';
-        header.dsp_map[slot].ylabel[0] = '\0';
+        header.dsp_map[slot].xlabel[0] = 0 ;
+        header.dsp_map[slot].ylabel[0] = 0;
         header.dsp_statistics[slot].overflows = [0, 0];
         header.dsp_statistics[slot].underflows = [0, 0];
 


### PR DESCRIPTION
*  sharedmem/mod.rs - rust characters are 32 bits wide because they are UTF-32 so the spectrum title type must be an array of u8 with appropriate modifications to the stuff that sets them.
*  Update the version to 0.1.1