### PR TITLE
Rfoxkendo/issue106

### DIFF
--- a/src/projections/mod.rs
+++ b/src/projections/mod.rs
@@ -1791,14 +1791,16 @@ mod project_tests {
     use crate::histogramer;
     use crate::messaging;
     use crate::messaging::{condition_messages, parameter_messages, spectrum_messages};
+    use crate::test::histogramer_common;
     use crate::trace;
+
     use std::sync::mpsc;
     use std::thread;
     // We need to run the histogram server.
     // and have some parameters and a contour and a source spectrum or two.
 
     fn setup() -> (mpsc::Sender<messaging::Request>, thread::JoinHandle<()>) {
-        let (jh, ch) = histogramer::start_server(trace::SharedTraceStore::new());
+        let (ch, jh) = histogramer_common::setup();
         let papi = parameter_messages::ParameterMessageClient::new(&ch);
         let capi = condition_messages::ConditionMessageClient::new(&ch);
         let sapi = spectrum_messages::SpectrumMessageClient::new(&ch);
@@ -1837,8 +1839,7 @@ mod project_tests {
         (ch, jh)
     }
     fn teardown(ch: mpsc::Sender<messaging::Request>, jh: thread::JoinHandle<()>) {
-        histogramer::stop_server(&ch);
-        jh.join().expect("Joining with histogram server.")
+        histogramer_common::teardown(ch, jh);
     }
 
     fn get_spectrum_info(

--- a/src/projections/mod.rs
+++ b/src/projections/mod.rs
@@ -882,20 +882,17 @@ mod recons_contour_tests {
 #[cfg(test)]
 mod make_spectrum_tests {
     use super::*;
-    use crate::histogramer;
     use crate::messaging;
     use crate::messaging::{parameter_messages, spectrum_messages};
-    use crate::trace;
+    use crate::test::histogramer_common;
     use std::sync::mpsc;
     use std::thread;
 
     fn setup() -> (mpsc::Sender<messaging::Request>, thread::JoinHandle<()>) {
-        let (jh, send) = histogramer::start_server(trace::SharedTraceStore::new());
-        (send, jh)
+        histogramer_common::setup()
     }
     fn teardown(ch: mpsc::Sender<messaging::Request>, jh: thread::JoinHandle<()>) {
-        histogramer::stop_server(&ch);
-        jh.join().unwrap();
+        histogramer_common::teardown(ch, jh);
     }
 
     #[test]

--- a/src/sharedmem/binder.rs
+++ b/src/sharedmem/binder.rs
@@ -1144,7 +1144,7 @@ mod sbind_trace_tests {
     //  The shared trace store.
     //
 
-    fn start_servers() -> (
+    fn setup() -> (
         mpsc::Sender<messaging::Request>,
         mpsc::Sender<Request>, // Binder.
         trace::SharedTraceStore,
@@ -1162,9 +1162,9 @@ mod sbind_trace_tests {
             binder_join,
         )
     }
-    // Stop_servers
+    // teardown
 
-    fn stop_servers(
+    fn teardown(
         hreq: mpsc::Sender<messaging::Request>,
         hjoin: thread::JoinHandle<()>,
         bindreq: mpsc::Sender<Request>,
@@ -1178,7 +1178,7 @@ mod sbind_trace_tests {
     fn bind_1() {
         // Make a spectrum, bind it - should get a single SpectrumBound event.
 
-        let (hreq, binder_req, tracedb, hjoin, bjoin) = start_servers();
+        let (hreq, binder_req, tracedb, hjoin, bjoin) = setup();
 
         // Make a parameter and a 1d spectrum:
 
@@ -1210,14 +1210,14 @@ mod sbind_trace_tests {
         } else {
             false
         });
-        stop_servers(hreq, hjoin, binder_req, bjoin);
+        teardown(hreq, hjoin, binder_req, bjoin);
     }
     #[test]
     fn unbind_1() {
         // Make several spectra and bind them all.  Then unbind one of them.
         // we should get a SpectrumUnbound event for that.
 
-        let (hreq, binder_req, tracedb, hjoin, bjoin) = start_servers();
+        let (hreq, binder_req, tracedb, hjoin, bjoin) = setup();
 
         // Make a parameter and a 1d spectrum:
 
@@ -1250,14 +1250,14 @@ mod sbind_trace_tests {
             false
         });
 
-        stop_servers(hreq, hjoin, binder_req, bjoin);
+        teardown(hreq, hjoin, binder_req, bjoin);
     }
     #[test]
     fn unbind_2() {
         // Using unbind_all allows all bound spectra to be unbound
         // we'll make a set of spectra, bind them all and then
         // ensure we have unbind traces for all of them.
-        let (hreq, binder_req, tracedb, hjoin, bjoin) = start_servers();
+        let (hreq, binder_req, tracedb, hjoin, bjoin) = setup();
         // Make several spectra and bind them all.  Then unbind one of them.
         // we should get a SpectrumUnbound event for that.
 
@@ -1300,6 +1300,6 @@ mod sbind_trace_tests {
             assert!(traced_names.contains(&name), "Missing {}", n);
         }
 
-        stop_servers(hreq, hjoin, binder_req, bjoin);
+        teardown(hreq, hjoin, binder_req, bjoin);
     }
 }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -109,3 +109,25 @@ pub mod histogramer_common {
         jh.join().unwrap();
     }
 }
+#[cfg(test)]
+pub mod binder_common {
+    use crate::messaging;
+    use crate::sharedmem::binder;
+    use crate::trace;
+    use std::sync::mpsc;
+    use std::thread;
+    
+    pub fn setup(hreq: &mpsc::Sender<messaging::Request>) -> (mpsc::Sender<binder::Request>, thread::JoinHandle<()>, trace::SharedTraceStore)  {
+        let tracedb = trace::SharedTraceStore::new();
+        let (binder_req, binder_join) = binder::start_server(hreq, 1024 * 1024, &tracedb);
+
+        (binder_req, binder_join, tracedb)
+    }
+    pub fn teardown(breq : mpsc::Sender<binder::Request>, jh: thread::JoinHandle<()>) {
+
+        let api = binder::BindingApi::new(&breq);
+        api.exit().expect("Stopping binding server");
+        jh.join().expect("Joining binder thread");
+    }
+
+}

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -90,3 +90,22 @@ pub mod rest_common {
         (chan, papi, binder_api)
     }
 }
+// Common test code for tests that need a histogramer active:
+#[cfg(test)]
+pub mod histogramer_common {
+    use crate::histogramer;
+    use crate::messaging;
+    use crate::trace;
+
+    use std::sync::mpsc;
+    use std::thread;
+
+    pub fn setup() -> (mpsc::Sender<messaging::Request>, thread::JoinHandle<()>) {
+        let (jh, send) = histogramer::start_server(trace::SharedTraceStore::new());
+        (send, jh)
+    }
+    pub fn teardown(ch: mpsc::Sender<messaging::Request>, jh: thread::JoinHandle<()>) {
+        histogramer::stop_server(&ch);
+        jh.join().unwrap();
+    }
+}


### PR DESCRIPTION
Factor out common test setup/teardown code  into submodues of crate::test  specifically histogramer_common and binder_common.