### PR TITLE
Rfoxkendo/issue120

### DIFF
--- a/src/conditions/compound.rs
+++ b/src/conditions/compound.rs
@@ -76,7 +76,7 @@ impl Condition for Not {
     fn condition_points(&self) -> Vec<(f64, f64)> {
         Vec::<(f64, f64)>::new()
     }
-    fn dependent_gates(&self) -> Vec<ContainerReference> {
+    fn dependent_conditions(&self) -> Vec<ContainerReference> {
         vec![self.dependent.clone()]
     }
     fn dependent_parameters(&self) -> Vec<u32> {
@@ -180,7 +180,7 @@ impl Condition for And {
         Vec::<(f64, f64)>::new()
     }
 
-    fn dependent_gates(&self) -> Vec<ContainerReference> {
+    fn dependent_conditions(&self) -> Vec<ContainerReference> {
         self.dependencies.clone_conditions()
     }
     fn dependent_parameters(&self) -> Vec<u32> {
@@ -257,7 +257,7 @@ impl Condition for Or {
         Vec::<(f64, f64)>::new()
     }
 
-    fn dependent_gates(&self) -> Vec<ContainerReference> {
+    fn dependent_conditions(&self) -> Vec<ContainerReference> {
         self.dependencies.clone_conditions()
     }
     fn dependent_parameters(&self) -> Vec<u32> {

--- a/src/conditions/compound.rs
+++ b/src/conditions/compound.rs
@@ -70,7 +70,7 @@ impl Condition for Not {
             d.borrow_mut().invalidate_cache();
         }
     }
-    fn gate_type(&self) -> String {
+    fn condition_type(&self) -> String {
         String::from("Not")
     }
     fn gate_points(&self) -> Vec<(f64, f64)> {
@@ -173,7 +173,7 @@ impl Condition for And {
         self.dependencies.cache = Some(result);
         result
     }
-    fn gate_type(&self) -> String {
+    fn condition_type(&self) -> String {
         String::from("And")
     }
     fn gate_points(&self) -> Vec<(f64, f64)> {
@@ -250,7 +250,7 @@ impl Condition for Or {
         self.dependencies.cache = Some(result);
         result
     }
-    fn gate_type(&self) -> String {
+    fn condition_type(&self) -> String {
         String::from("Or")
     }
     fn gate_points(&self) -> Vec<(f64, f64)> {

--- a/src/conditions/compound.rs
+++ b/src/conditions/compound.rs
@@ -73,7 +73,7 @@ impl Condition for Not {
     fn condition_type(&self) -> String {
         String::from("Not")
     }
-    fn gate_points(&self) -> Vec<(f64, f64)> {
+    fn condition_points(&self) -> Vec<(f64, f64)> {
         Vec::<(f64, f64)>::new()
     }
     fn dependent_gates(&self) -> Vec<ContainerReference> {
@@ -176,7 +176,7 @@ impl Condition for And {
     fn condition_type(&self) -> String {
         String::from("And")
     }
-    fn gate_points(&self) -> Vec<(f64, f64)> {
+    fn condition_points(&self) -> Vec<(f64, f64)> {
         Vec::<(f64, f64)>::new()
     }
 
@@ -253,7 +253,7 @@ impl Condition for Or {
     fn condition_type(&self) -> String {
         String::from("Or")
     }
-    fn gate_points(&self) -> Vec<(f64, f64)> {
+    fn condition_points(&self) -> Vec<(f64, f64)> {
         Vec::<(f64, f64)>::new()
     }
 

--- a/src/conditions/compound.rs
+++ b/src/conditions/compound.rs
@@ -2,7 +2,7 @@
 //!  These are called *dependent conditions*.  Dependent conditions can be
 //!  Either primitive conditions, like cuts or contours, or they can be other
 //!  Compund conditions.  This nesting allows one to build up arbitrarily
-//!  Complex gate logic.  The compund conditions that we define are:
+//!  Complex condition logic.  The compund conditions that we define are:
 //!  
 //!  *  Not - takes a single condition and returns its boolean negation.
 //!  *  And - takes an arbitrary number of dependent conditions and
@@ -10,12 +10,12 @@
 //!  *  Or - takes an arbitrary number of dependent conditions and
 //! Requires at least one to be true.
 //!
-//!  Compound conditions make not promise that their dependent gates are
+//!  Compound conditions make not promise that their dependent conditions are
 //!  Fully evaluated.  It's perfectly fair game (and is the case) that
 //!  Short circuit logic can be used to reduce the number of conditions
 //!  that need to be evaluated until the truth or falsity of the
-//!  main condition is known. All of these gate cache as well which
-//!  further reduces the number of gate evaluation needed if a
+//!  main condition is known. All of these conditions cache as well which
+//!  further reduces the number of condition evaluation needed if a
 //!  compound condition is applied to more than one target.
 //!
 //!  And and Or conditions depend on a cache and a vector of dependent conditions,
@@ -152,7 +152,7 @@ impl And {
 }
 impl Condition for And {
     fn evaluate(&mut self, event: &FlatEvent) -> bool {
-        let mut result = true; // Failed gates will contradict this.
+        let mut result = true; // Failed conditions will contradict this.
 
         if let Some(c) = self.dependencies.cache {
             return c;
@@ -325,7 +325,7 @@ mod and_tests {
     }
     #[test]
     fn add_1() {
-        // Add a T gate
+        // Add a T condition
 
         let t = True {};
         let c: Container = Rc::new(RefCell::new(Box::new(t)));
@@ -335,7 +335,7 @@ mod and_tests {
     }
     #[test]
     fn add_2() {
-        // add a t and an f gate:
+        // add a t and an f condition:
 
         let t = True {};
         let f = False {};
@@ -368,7 +368,7 @@ mod and_tests {
     }
     #[test]
     fn check_1() {
-        // And gates are true if there are no entries:
+        // And conditions are true if there are no entries:
 
         let mut a = And::new();
         let e = FlatEvent::new();
@@ -381,7 +381,7 @@ mod and_tests {
     }
     #[test]
     fn check_2() {
-        // a single T gate is true:
+        // a single T condition is true:
 
         let mut a = And::new();
         let e = FlatEvent::new();
@@ -508,7 +508,7 @@ mod or_tests {
     }
     #[test]
     fn check_1() {
-        // empty gate is true:
+        // empty condition is true:
 
         let mut o = Or::new();
         let e = FlatEvent::new();
@@ -516,7 +516,7 @@ mod or_tests {
     }
     #[test]
     fn check_2() {
-        //Single true gate gives true:
+        //Single true condition gives true:
 
         let mut o = Or::new();
         let e = FlatEvent::new();

--- a/src/conditions/cut.rs
+++ b/src/conditions/cut.rs
@@ -59,7 +59,7 @@ impl Condition for Cut {
     fn condition_points(&self) -> Vec<(f64, f64)> {
         vec![(self.low, 0.0), (self.high, 0.0)]
     }
-    fn dependent_gates(&self) -> Vec<ContainerReference> {
+    fn dependent_conditions(&self) -> Vec<ContainerReference> {
         Vec::<ContainerReference>::new()
     }
     fn get_cached_value(&self) -> Option<bool> {
@@ -125,7 +125,7 @@ impl Condition for MultiCut {
     fn condition_points(&self) -> Vec<(f64, f64)> {
         vec![(self.low, 0.0), (self.high, 0.0)]
     }
-    fn dependent_gates(&self) -> Vec<ContainerReference> {
+    fn dependent_conditions(&self) -> Vec<ContainerReference> {
         vec![]
     }
     fn dependent_parameters(&self) -> Vec<u32> {
@@ -452,7 +452,7 @@ mod multicut_tests {
     #[test]
     fn dependencies_1() {
         let mcut = MultiCut::new(&[1, 2, 3], 100.0, 200.0);
-        assert!(mcut.dependent_gates().is_empty());
+        assert!(mcut.dependent_conditions().is_empty());
         assert_eq!(vec![1, 2, 3], mcut.dependent_parameters());
     }
     #[test]

--- a/src/conditions/cut.rs
+++ b/src/conditions/cut.rs
@@ -53,7 +53,7 @@ impl Condition for Cut {
         self.cache = Some(result);
         result
     }
-    fn gate_type(&self) -> String {
+    fn condition_type(&self) -> String {
         String::from("Cut")
     }
     fn gate_points(&self) -> Vec<(f64, f64)> {
@@ -119,7 +119,7 @@ impl Condition for MultiCut {
         self.cache = Some(false);
         false
     }
-    fn gate_type(&self) -> String {
+    fn condition_type(&self) -> String {
         String::from("MultiCut")
     }
     fn gate_points(&self) -> Vec<(f64, f64)> {
@@ -438,7 +438,7 @@ mod multicut_tests {
         // Condition type should be "MultiCut"
 
         let mcut = MultiCut::new(&[1, 2, 3], 100.0, 200.0);
-        assert_eq!("MultiCut", mcut.gate_type());
+        assert_eq!("MultiCut", mcut.condition_type());
     }
     #[test]
     fn points_1() {

--- a/src/conditions/cut.rs
+++ b/src/conditions/cut.rs
@@ -56,7 +56,7 @@ impl Condition for Cut {
     fn condition_type(&self) -> String {
         String::from("Cut")
     }
-    fn gate_points(&self) -> Vec<(f64, f64)> {
+    fn condition_points(&self) -> Vec<(f64, f64)> {
         vec![(self.low, 0.0), (self.high, 0.0)]
     }
     fn dependent_gates(&self) -> Vec<ContainerReference> {
@@ -122,7 +122,7 @@ impl Condition for MultiCut {
     fn condition_type(&self) -> String {
         String::from("MultiCut")
     }
-    fn gate_points(&self) -> Vec<(f64, f64)> {
+    fn condition_points(&self) -> Vec<(f64, f64)> {
         vec![(self.low, 0.0), (self.high, 0.0)]
     }
     fn dependent_gates(&self) -> Vec<ContainerReference> {
@@ -442,10 +442,10 @@ mod multicut_tests {
     }
     #[test]
     fn points_1() {
-        // Test gate_points:
+        // Test condition_points:
 
         let mcut = MultiCut::new(&[1, 2, 3], 100.0, 200.0);
-        assert_eq!(vec![(100.0, 0.0), (200.0, 0.0)], mcut.gate_points());
+        assert_eq!(vec![(100.0, 0.0), (200.0, 0.0)], mcut.condition_points());
     }
     // Dependent conditionss and parameters are empty:
 

--- a/src/conditions/cut.rs
+++ b/src/conditions/cut.rs
@@ -6,7 +6,7 @@
 //!  *  The parameter value is in the range [low, high] for that
 //! event.
 //! Cut conditions are defined to support caching.  That is
-//! Having evaluated the condition for the gate, get_cached_value
+//! Having evaluated the condition for the condition, get_cached_value
 //! Will return Some containing the value of the last evaluation
 //! until the cache is explicitly invalidated.
 //!
@@ -384,7 +384,7 @@ mod multicut_tests {
     }
     #[test]
     fn eval_2() {
-        // Inside gate but not all params are present:
+        // Inside condition but not all params are present:
 
         let mut mcut = MultiCut::new(&[1, 2, 3], 100.0, 200.0);
         let event: Event = vec![EventParameter::new(2, 150.0)];
@@ -435,7 +435,7 @@ mod multicut_tests {
     }
     #[test]
     fn type_1() {
-        // Gate type should be "MultiCut"
+        // Condition type should be "MultiCut"
 
         let mcut = MultiCut::new(&[1, 2, 3], 100.0, 200.0);
         assert_eq!("MultiCut", mcut.gate_type());
@@ -447,7 +447,7 @@ mod multicut_tests {
         let mcut = MultiCut::new(&[1, 2, 3], 100.0, 200.0);
         assert_eq!(vec![(100.0, 0.0), (200.0, 0.0)], mcut.gate_points());
     }
-    // Dependent gatews and parameters are empty:
+    // Dependent conditionss and parameters are empty:
 
     #[test]
     fn dependencies_1() {

--- a/src/conditions/mod.rs
+++ b/src/conditions/mod.rs
@@ -84,7 +84,7 @@ pub trait Condition {
 
     // Stuff to describe a condition:
 
-    fn gate_type(&self) -> String; // Type of Condition.
+    fn condition_type(&self) -> String; // Type of Condition.
     fn gate_points(&self) -> Vec<(f64, f64)>;
     fn dependent_gates(&self) -> Vec<ContainerReference>;
     fn dependent_parameters(&self) -> Vec<u32>;
@@ -247,7 +247,7 @@ impl Condition for True {
     fn evaluate(&mut self, _event: &parameters::FlatEvent) -> bool {
         true
     }
-    fn gate_type(&self) -> String {
+    fn condition_type(&self) -> String {
         String::from("True")
     }
     fn gate_points(&self) -> Vec<(f64, f64)> {
@@ -270,7 +270,7 @@ impl Condition for False {
     fn evaluate(&mut self, _event: &parameters::FlatEvent) -> bool {
         false
     }
-    fn gate_type(&self) -> String {
+    fn condition_type(&self) -> String {
         String::from("False")
     }
     fn gate_points(&self) -> Vec<(f64, f64)> {

--- a/src/conditions/mod.rs
+++ b/src/conditions/mod.rs
@@ -207,7 +207,7 @@ pub type ConditionDictionary = HashMap<String, Container>;
 ///  we iterate over all key value pairs and if we find one where the
 ///  RefCell's in the container point to the same underlying object, we
 ///  return its name.
-pub fn gate_name(dict: &ConditionDictionary, condition: &Container) -> Option<String> {
+pub fn condition_name(dict: &ConditionDictionary, condition: &Container) -> Option<String> {
     for (k, v) in dict.iter() {
         if condition.as_ptr() == v.as_ptr() {
             // Same underlying conditions.
@@ -216,12 +216,12 @@ pub fn gate_name(dict: &ConditionDictionary, condition: &Container) -> Option<St
     }
     None
 }
-pub fn gate_name_from_ref(
+pub fn condition_name_from_ref(
     dict: &ConditionDictionary,
     condition: &ContainerReference,
 ) -> Option<String> {
     if let Some(s) = condition.upgrade() {
-        gate_name(dict, &s)
+        condition_name(dict, &s)
     } else {
         None
     }

--- a/src/conditions/mod.rs
+++ b/src/conditions/mod.rs
@@ -9,9 +9,9 @@
 //!  defined by this module.
 //!
 //!  For spectra to have a condition applied to them, they need
-//!  some reference to a gate which is evaluated over each event
+//!  some reference to a condition which is evaluated over each event
 //!  polymorphically.  In the case of SpecTcl this is handled using
-//!  C++ virtual functions and gate container pointer-like objects.
+//!  C++ virtual functions and condition container pointer-like objects.
 //!  For Rust, the mechanism of dynamic dispatch requires the use
 //!  of *trait objects*   A trait object is a pointer like container
 //!  (e.g. Rc or Box) which is defined to contain/reference an
@@ -22,7 +22,7 @@
 //!  In our case, in order to support transparent replacement, we'll use
 //!  `Rc<dyn Condition>`.  These get cloned to pass them to
 //!  spectra where Rc::downgrade() turns them into Weak references.
-//!  This trick will get around the SpecTcl problem of *etnernal gates*
+//!  This trick will get around the SpecTcl problem of *eternal gates*
 //!  Since it's too much trouble, in general, to track down all
 //!  references to a conition, in SpecTcl, gates are never deleted, but
 //!  turned into False  gates.  This provide known behavior but some
@@ -65,7 +65,7 @@ pub mod twod;
 pub use twod::*;
 
 /// The Container trait defines the interface to a condition through
-/// a gate container.   This interface includes:
+/// a Condition container.   This interface includes:
 /// *  Support for an evaluation of the condition for a flattened
 /// event
 /// *  Support for caching the evaluation of the condition
@@ -82,9 +82,9 @@ pub trait Condition {
     ///
     fn evaluate(&mut self, event: &parameters::FlatEvent) -> bool;
 
-    // Stuff to describe a gate:
+    // Stuff to describe a condition:
 
-    fn gate_type(&self) -> String; // Type of gate.
+    fn gate_type(&self) -> String; // Type of Condition.
     fn gate_points(&self) -> Vec<(f64, f64)>;
     fn dependent_gates(&self) -> Vec<ContainerReference>;
     fn dependent_parameters(&self) -> Vec<u32>;
@@ -97,7 +97,7 @@ pub trait Condition {
     }
     fn invalidate_cache(&mut self) {}
     ///
-    /// The method that really sould be called to check a gate:
+    /// The method that really sould be called to check a condition:
     /// If the object has a cached value, the cached value
     /// is returned, otherwise the evaluate, required method is
     /// invoked to force condition evaluation.
@@ -207,17 +207,20 @@ pub type ConditionDictionary = HashMap<String, Container>;
 ///  we iterate over all key value pairs and if we find one where the
 ///  RefCell's in the container point to the same underlying object, we
 ///  return its name.
-pub fn gate_name(dict: &ConditionDictionary, gate: &Container) -> Option<String> {
+pub fn gate_name(dict: &ConditionDictionary, condition: &Container) -> Option<String> {
     for (k, v) in dict.iter() {
-        if gate.as_ptr() == v.as_ptr() {
-            // Same underlying gates.
+        if condition.as_ptr() == v.as_ptr() {
+            // Same underlying conditions.
             return Some(k.clone());
         }
     }
     None
 }
-pub fn gate_name_from_ref(dict: &ConditionDictionary, gate: &ContainerReference) -> Option<String> {
-    if let Some(s) = gate.upgrade() {
+pub fn gate_name_from_ref(
+    dict: &ConditionDictionary,
+    condition: &ContainerReference,
+) -> Option<String> {
+    if let Some(s) = condition.upgrade() {
         gate_name(dict, &s)
     } else {
         None
@@ -235,10 +238,10 @@ pub fn invalidate_cache(d: &mut ConditionDictionary) {
     }
 }
 
-/// The True gate is implemented in this module and returns True
+/// The True condition is implemented in this module and returns True
 /// no matter what the event contains.  It serves as a trival example
 /// of how conditions can be implemented.  No caching is required
-/// for the True gate:
+/// for the True condition:
 pub struct True {}
 impl Condition for True {
     fn evaluate(&mut self, _event: &parameters::FlatEvent) -> bool {

--- a/src/conditions/mod.rs
+++ b/src/conditions/mod.rs
@@ -86,7 +86,7 @@ pub trait Condition {
 
     fn condition_type(&self) -> String; // Type of Condition.
     fn condition_points(&self) -> Vec<(f64, f64)>;
-    fn dependent_gates(&self) -> Vec<ContainerReference>;
+    fn dependent_conditions(&self) -> Vec<ContainerReference>;
     fn dependent_parameters(&self) -> Vec<u32>;
 
     /// Optional methods:
@@ -253,7 +253,7 @@ impl Condition for True {
     fn condition_points(&self) -> Vec<(f64, f64)> {
         Vec::<(f64, f64)>::new()
     }
-    fn dependent_gates(&self) -> Vec<ContainerReference> {
+    fn dependent_conditions(&self) -> Vec<ContainerReference> {
         Vec::<ContainerReference>::new()
     }
     fn dependent_parameters(&self) -> Vec<u32> {
@@ -276,7 +276,7 @@ impl Condition for False {
     fn condition_points(&self) -> Vec<(f64, f64)> {
         Vec::<(f64, f64)>::new()
     }
-    fn dependent_gates(&self) -> Vec<ContainerReference> {
+    fn dependent_conditions(&self) -> Vec<ContainerReference> {
         Vec::<ContainerReference>::new()
     }
     fn dependent_parameters(&self) -> Vec<u32> {

--- a/src/conditions/mod.rs
+++ b/src/conditions/mod.rs
@@ -85,7 +85,7 @@ pub trait Condition {
     // Stuff to describe a condition:
 
     fn condition_type(&self) -> String; // Type of Condition.
-    fn gate_points(&self) -> Vec<(f64, f64)>;
+    fn condition_points(&self) -> Vec<(f64, f64)>;
     fn dependent_gates(&self) -> Vec<ContainerReference>;
     fn dependent_parameters(&self) -> Vec<u32>;
 
@@ -250,7 +250,7 @@ impl Condition for True {
     fn condition_type(&self) -> String {
         String::from("True")
     }
-    fn gate_points(&self) -> Vec<(f64, f64)> {
+    fn condition_points(&self) -> Vec<(f64, f64)> {
         Vec::<(f64, f64)>::new()
     }
     fn dependent_gates(&self) -> Vec<ContainerReference> {
@@ -273,7 +273,7 @@ impl Condition for False {
     fn condition_type(&self) -> String {
         String::from("False")
     }
-    fn gate_points(&self) -> Vec<(f64, f64)> {
+    fn condition_points(&self) -> Vec<(f64, f64)> {
         Vec::<(f64, f64)>::new()
     }
     fn dependent_gates(&self) -> Vec<ContainerReference> {

--- a/src/conditions/twod.rs
+++ b/src/conditions/twod.rs
@@ -199,7 +199,7 @@ impl Condition for Band {
             false
         }
     }
-    fn gate_type(&self) -> String {
+    fn condition_type(&self) -> String {
         String::from("Band")
     }
     fn gate_points(&self) -> Vec<(f64, f64)> {
@@ -359,7 +359,7 @@ impl Condition for Contour {
         self.cache = Some(result);
         result
     }
-    fn gate_type(&self) -> String {
+    fn condition_type(&self) -> String {
         String::from("Contour")
     }
     fn gate_points(&self) -> Vec<(f64, f64)> {
@@ -451,7 +451,7 @@ impl Condition for MultiContour {
         self.cache = Some(false);
         false
     }
-    fn gate_type(&self) -> String {
+    fn condition_type(&self) -> String {
         String::from("MultiContour")
     }
     fn gate_points(&self) -> Vec<(f64, f64)> {
@@ -1243,7 +1243,7 @@ mod multicontour_tests {
     #[test]
     fn type_1() {
         let c = MultiContour::new(&vec![1, 2, 3], test_points()).expect("making multicontour");
-        assert_eq!("MultiContour", c.gate_type());
+        assert_eq!("MultiContour", c.condition_type());
     }
     #[test]
     fn points_1() {

--- a/src/conditions/twod.rs
+++ b/src/conditions/twod.rs
@@ -202,7 +202,7 @@ impl Condition for Band {
     fn condition_type(&self) -> String {
         String::from("Band")
     }
-    fn gate_points(&self) -> Vec<(f64, f64)> {
+    fn condition_points(&self) -> Vec<(f64, f64)> {
         let mut result = Vec::<(f64, f64)>::new();
         for p in self.points.iter() {
             result.push((p.x, p.y));
@@ -362,7 +362,7 @@ impl Condition for Contour {
     fn condition_type(&self) -> String {
         String::from("Contour")
     }
-    fn gate_points(&self) -> Vec<(f64, f64)> {
+    fn condition_points(&self) -> Vec<(f64, f64)> {
         let mut result = Vec::<(f64, f64)>::new();
         for p in self.pts.iter() {
             result.push((p.x, p.y));
@@ -454,8 +454,8 @@ impl Condition for MultiContour {
     fn condition_type(&self) -> String {
         String::from("MultiContour")
     }
-    fn gate_points(&self) -> Vec<(f64, f64)> {
-        self.contour.gate_points() // Can delegate.
+    fn condition_points(&self) -> Vec<(f64, f64)> {
+        self.contour.condition_points() // Can delegate.
     }
     fn dependent_gates(&self) -> Vec<ContainerReference> {
         vec![] // could delegate but this is simpler
@@ -1250,7 +1250,7 @@ mod multicontour_tests {
         let pts = test_points();
         let c = MultiContour::new(&vec![1, 2, 3], pts.clone()).expect("making multicontour");
 
-        let condition_pts = c.gate_points();
+        let condition_pts = c.condition_points();
         assert_eq!(pts.len(), condition_pts.len());
         for (i, p) in pts.iter().enumerate() {
             assert_eq!((p.x, p.y), condition_pts[i], "Mismatch on {}", i);

--- a/src/conditions/twod.rs
+++ b/src/conditions/twod.rs
@@ -9,7 +9,7 @@
 //!
 //!  Each of these has its own requirements and definitions of
 //!  acceptance.  Since the computations required to compute if
-//!  A gate has been made may be time consuming, all of these
+//!  A condition has been made may be time consuming, all of these
 //!  conditions cache.
 //!
 //! ## Bands
@@ -410,7 +410,7 @@ impl MultiContour {
     /// Create a new contour.
     ///
     /// ### Parameters:
-    ///  *  parameters the parameters that are actually used for the gate/fold.
+    ///  *  parameters the parameters that are actually used for the condition/fold.
     ///  *  pts  - the points that define the contour.
     ///
     pub fn new(parameters: &[u32], pts: Points) -> Option<MultiContour> {
@@ -1250,10 +1250,10 @@ mod multicontour_tests {
         let pts = test_points();
         let c = MultiContour::new(&vec![1, 2, 3], pts.clone()).expect("making multicontour");
 
-        let gate_pts = c.gate_points();
-        assert_eq!(pts.len(), gate_pts.len());
+        let condition_pts = c.gate_points();
+        assert_eq!(pts.len(), condition_pts.len());
         for (i, p) in pts.iter().enumerate() {
-            assert_eq!((p.x, p.y), gate_pts[i], "Mismatch on {}", i);
+            assert_eq!((p.x, p.y), condition_pts[i], "Mismatch on {}", i);
         }
     }
     #[test]

--- a/src/conditions/twod.rs
+++ b/src/conditions/twod.rs
@@ -210,7 +210,7 @@ impl Condition for Band {
 
         result
     }
-    fn dependent_gates(&self) -> Vec<ContainerReference> {
+    fn dependent_conditions(&self) -> Vec<ContainerReference> {
         Vec::<ContainerReference>::new()
     }
     fn dependent_parameters(&self) -> Vec<u32> {
@@ -370,7 +370,7 @@ impl Condition for Contour {
 
         result
     }
-    fn dependent_gates(&self) -> Vec<ContainerReference> {
+    fn dependent_conditions(&self) -> Vec<ContainerReference> {
         Vec::<ContainerReference>::new()
     }
     fn dependent_parameters(&self) -> Vec<u32> {
@@ -457,7 +457,7 @@ impl Condition for MultiContour {
     fn condition_points(&self) -> Vec<(f64, f64)> {
         self.contour.condition_points() // Can delegate.
     }
-    fn dependent_gates(&self) -> Vec<ContainerReference> {
+    fn dependent_conditions(&self) -> Vec<ContainerReference> {
         vec![] // could delegate but this is simpler
     }
     fn dependent_parameters(&self) -> Vec<u32> {
@@ -1260,7 +1260,7 @@ mod multicontour_tests {
     fn depcond_1() {
         let c = MultiContour::new(&vec![1, 2, 3], test_points()).expect("making multicontour");
 
-        assert!(c.dependent_gates().is_empty());
+        assert!(c.dependent_conditions().is_empty());
     }
     #[test]
     fn deppars_1() {

--- a/src/histogramer/mod.rs
+++ b/src/histogramer/mod.rs
@@ -196,7 +196,8 @@ mod request_tests {
             false
         });
         let d = req.conditions.get_dict();
-        d.get(&String::from("true")).expect("Failed condition lookup");
+        d.get(&String::from("true"))
+            .expect("Failed condition lookup");
     }
     #[test]
     fn spec_clear_1() {

--- a/src/histogramer/mod.rs
+++ b/src/histogramer/mod.rs
@@ -196,7 +196,7 @@ mod request_tests {
             false
         });
         let d = req.conditions.get_dict();
-        d.get(&String::from("true")).expect("Failed gate lookup");
+        d.get(&String::from("true")).expect("Failed condition lookup");
     }
     #[test]
     fn spec_clear_1() {

--- a/src/messaging/condition_messages.rs
+++ b/src/messaging/condition_messages.rs
@@ -222,9 +222,9 @@ impl ConditionMessageClient {
     ///  *  name - name of the true condition to create.
     ///
     /// Returns ConditionReply.   On success this is either
-    /// *   Created - this was a new gate.
-    /// *   Replaced - An exsting gate by that name was replaced by
-    /// this true gate.
+    /// *   Created - this was a new condition.
+    /// *   Replaced - An exsting condition by that name was replaced by
+    /// this true condition.
     ///
     /// Other returns are errors.
     pub fn create_true_condition(&self, name: &str) -> ConditionReply {
@@ -234,9 +234,9 @@ impl ConditionMessageClient {
     ///  *  name - name of the false condition to create.
     ///
     /// Returns ConditionReply.   On success this is either
-    /// *   Created - this was a new gate.
-    /// *   Replaced - An exsting gate by that name was replaced by
-    /// this true gate.
+    /// *   Created - this was a new condition.
+    /// *   Replaced - An exsting condition by that name was replaced by
+    /// this true condition.
     ///
     /// Other returns are errors.
     pub fn create_false_condition(&self, name: &str) -> ConditionReply {
@@ -248,9 +248,9 @@ impl ConditionMessageClient {
     ///  *  dependent - name of the condition that will be negated by this
     /// condition.
     /// Returns ConditionReply.   On success this is either
-    /// *   Created - this was a new gate.
-    /// *   Replaced - An exsting gate by that name was replaced by
-    /// this true gate.
+    /// *   Created - this was a new condition.
+    /// *   Replaced - An exsting condition by that name was replaced by
+    /// this true condition.
     ///
     /// Other returns are errors.  Note that a very simple error is that the
     /// dependent condition does not yet exist.
@@ -266,9 +266,9 @@ impl ConditionMessageClient {
     /// the new condition true.
     ///
     /// Returns ConditionReply.   On success this is either
-    /// *   Created - this was a new gate.
-    /// *   Replaced - An exsting gate by that name was replaced by
-    /// this true gate.
+    /// *   Created - this was a new condition.
+    /// *   Replaced - An exsting condition by that name was replaced by
+    /// this true condition.
     ///
     /// Other returns are errors.  Note that a very simple error is that the
     /// one or more of the dependent conditions does not exist.
@@ -284,9 +284,9 @@ impl ConditionMessageClient {
     /// be true to make the new condition true.
     ///
     /// Returns ConditionReply.   On success this is either
-    /// *   Created - this was a new gate.
-    /// *   Replaced - An exsting gate by that name was replaced by
-    /// this new gate.
+    /// *   Created - this was a new condition.
+    /// *   Replaced - An exsting condition by that name was replaced by
+    /// this new condition.
     ///
     /// Other returns are errors.  Note that a very simple error is that the
     /// one or more of the dependent conditions does not exist.
@@ -302,9 +302,9 @@ impl ConditionMessageClient {
     ///  *  high - Cut high limit.
     ///
     /// Returns ConditionReply.   On success this is either
-    /// *   Created - this was a new gate.
-    /// *   Replaced - An exsting gate by that name was replaced by
-    /// this new gate.
+    /// *   Created - this was a new condition.
+    /// *   Replaced - An exsting condition by that name was replaced by
+    /// this new condition.
     ///
     /// Other returns are errors.  Note that the caller must have gotten the parameter_id
     /// in some way that makes it valid (e.g. from a list request to the
@@ -330,9 +330,9 @@ impl ConditionMessageClient {
     ///  *  points - The points that define the polyline events are checked against.
     ///
     /// Returns ConditionReply.   On success this is either
-    /// *   Created - this was a new gate.
-    /// *   Replaced - An exsting gate by that name was replaced by
-    /// this new gate.
+    /// *   Created - this was a new condition.
+    /// *   Replaced - An exsting condition by that name was replaced by
+    /// this new condition.
     ///
     /// Other returns are errors.  Note that the caller must have gotten parameer ids
     /// in some way that makes them valid (e.g. from a list request to the
@@ -365,9 +365,9 @@ impl ConditionMessageClient {
     /// checked against.
     ///
     /// Returns ConditionReply.   On success this is either
-    /// *   Created - this was a new gate.
-    /// *   Replaced - An exsting gate by that name was replaced by
-    /// this new gate.
+    /// *   Created - this was a new condition.
+    /// *   Replaced - An exsting condition by that name was replaced by
+    /// this new condition.
     ///
     /// Other returns are errors.  Note that the caller must have gotten parameer ids
     /// in some way that makes them valid (e.g. from a list request to the
@@ -514,7 +514,7 @@ impl ConditionProcessor {
             let n = Not::new(d);
             self.add_condition(name, n, tracedb)
         } else {
-            ConditionReply::Error(format!("Dependent gate {} not found", dependent))
+            ConditionReply::Error(format!("Dependent condition {} not found", dependent))
         }
     }
     fn add_and(
@@ -530,7 +530,7 @@ impl ConditionProcessor {
             if let Some(c) = self.dict.get(&n) {
                 a.add_condition(c);
             } else {
-                return ConditionReply::Error(format!("Dependent gate {} not found", name));
+                return ConditionReply::Error(format!("Dependent condition {} not found", name));
             }
         }
         self.add_condition(name, a, tracedb)
@@ -549,7 +549,7 @@ impl ConditionProcessor {
             if let Some(c) = self.dict.get(&n) {
                 o.add_condition(c);
             } else {
-                return ConditionReply::Error(format!("Dependent gate {} not found", name));
+                return ConditionReply::Error(format!("Dependent condition {} not found", name));
             }
         }
         self.add_condition(name, o, tracedb)
@@ -650,7 +650,7 @@ impl ConditionProcessor {
     // make CondtionPropreties from a condition and its name.
 
     fn make_props(&self, name: &str, c: &Container) -> ConditionProperties {
-        // Need to make the dependent gates:
+        // Need to make the dependent conditions:
         let dependencies = c.borrow().dependent_gates();
         let mut d_names = Vec::<String>::new();
         for d in dependencies.iter() {
@@ -1123,9 +1123,9 @@ mod cnd_processor_tests {
     fn make_band_1() {
         let mut cp = ConditionProcessor::new();
         let tracedb = trace::SharedTraceStore::new();
-        let gate_pts = vec![(0.0, 100.0), (50.0, 200.0), (100.0, 50.0), (200.0, 25.0)];
+        let condition_pts = vec![(0.0, 100.0), (50.0, 200.0), (100.0, 50.0), (200.0, 25.0)];
         let rep = cp.process_request(
-            ConditionMessageClient::make_band_creation("band", 10, 15, &gate_pts),
+            ConditionMessageClient::make_band_creation("band", 10, 15, &condition_pts),
             &tracedb,
         );
         assert_eq!(ConditionReply::Created, rep);
@@ -1133,8 +1133,8 @@ mod cnd_processor_tests {
         let cond = cp.dict.get("band").unwrap();
         assert_eq!(String::from("Band"), cond.borrow().gate_type());
         let pts = cond.borrow().gate_points();
-        assert_eq!(gate_pts.len(), pts.len());
-        for (i, p) in gate_pts.iter().enumerate() {
+        assert_eq!(condition_pts.len(), pts.len());
+        for (i, p) in condition_pts.iter().enumerate() {
             assert_eq!(p.0, pts[i].0);
             assert_eq!(p.1, pts[i].1);
         }
@@ -1143,9 +1143,9 @@ mod cnd_processor_tests {
     fn make_contour_1() {
         let mut cp = ConditionProcessor::new();
         let tracedb = trace::SharedTraceStore::new();
-        let gate_pts = vec![(0.0, 100.0), (50.0, 200.0), (100.0, 50.0), (200.0, 25.0)];
+        let condition_pts = vec![(0.0, 100.0), (50.0, 200.0), (100.0, 50.0), (200.0, 25.0)];
         let rep = cp.process_request(
-            ConditionMessageClient::make_contour_creation("contour", 10, 15, &gate_pts),
+            ConditionMessageClient::make_contour_creation("contour", 10, 15, &condition_pts),
             &tracedb,
         );
         assert_eq!(ConditionReply::Created, rep);
@@ -1153,8 +1153,8 @@ mod cnd_processor_tests {
         let cond = cp.dict.get("contour").unwrap();
         assert_eq!(String::from("Contour"), cond.borrow().gate_type());
         let pts = cond.borrow().gate_points();
-        assert_eq!(gate_pts.len(), pts.len());
-        for (i, p) in gate_pts.iter().enumerate() {
+        assert_eq!(condition_pts.len(), pts.len());
+        for (i, p) in condition_pts.iter().enumerate() {
             assert_eq!(p.0, pts[i].0);
             assert_eq!(p.1, pts[i].1);
         }
@@ -1166,19 +1166,19 @@ mod cnd_processor_tests {
         let mut cp = ConditionProcessor::new();
         let tracedb = trace::SharedTraceStore::new();
         cp.process_request(
-            ConditionMessageClient::make_true_creation("agate"),
+            ConditionMessageClient::make_true_creation("acondition"),
             &tracedb,
         );
 
-        let cond = cp.dict.get("agate").unwrap();
+        let cond = cp.dict.get("acondition").unwrap();
         assert_eq!("True", cond.borrow().gate_type());
         let cond = Rc::downgrade(cond); // Weak now
 
-        // Replacing the gate should happen transparently
+        // Replacing the condition should happen transparently
         // to our cond:
 
         let result = cp.process_request(
-            ConditionMessageClient::make_false_creation("agate"),
+            ConditionMessageClient::make_false_creation("acondition"),
             &tracedb,
         );
         assert_eq!(ConditionReply::Replaced, result);
@@ -1198,7 +1198,7 @@ mod cnd_processor_tests {
             &tracedb,
         );
 
-        // Delete the true gate
+        // Delete the true condition
 
         let reply = cp.process_request(ConditionMessageClient::make_delete("true"), &tracedb);
         assert_eq!(ConditionReply::Deleted, reply); // Success.
@@ -1246,7 +1246,7 @@ mod cnd_processor_tests {
     }
     #[test]
     fn list_1() {
-        // List all gates:
+        // List all conditions:
         let mut cp = make_list_conditions();
         let tracedb = trace::SharedTraceStore::new();
         let reply = cp.process_request(ConditionMessageClient::make_list("*"), &tracedb);
@@ -1285,7 +1285,7 @@ mod cnd_processor_tests {
     }
     #[test]
     fn list_2() {
-        // List gates whose names start with "f"
+        // List conditions whose names start with "f"
 
         let mut cp = make_list_conditions();
         let tracedb = trace::SharedTraceStore::new();

--- a/src/messaging/condition_messages.rs
+++ b/src/messaging/condition_messages.rs
@@ -651,7 +651,7 @@ impl ConditionProcessor {
 
     fn make_props(&self, name: &str, c: &Container) -> ConditionProperties {
         // Need to make the dependent conditions:
-        let dependencies = c.borrow().dependent_gates();
+        let dependencies = c.borrow().dependent_conditions();
         let mut d_names = Vec::<String>::new();
         for d in dependencies.iter() {
             if let Some(s) = condition_name_from_ref(&self.dict, d) {
@@ -1037,7 +1037,7 @@ mod cnd_processor_tests {
         assert!(item.is_some());
         let cond = item.unwrap();
         assert_eq!(String::from("Not"), cond.borrow().condition_type());
-        let dep = cond.borrow().dependent_gates();
+        let dep = cond.borrow().dependent_conditions();
         assert_eq!(1, dep.len());
         assert_eq!(
             String::from("False"),
@@ -1064,7 +1064,7 @@ mod cnd_processor_tests {
 
         let cond = cp.dict.get("and").unwrap();
         assert_eq!(String::from("And"), cond.borrow().condition_type());
-        let deps = cond.borrow().dependent_gates();
+        let deps = cond.borrow().dependent_conditions();
 
         assert_eq!(2, deps.len());
         assert_eq!(
@@ -1096,7 +1096,7 @@ mod cnd_processor_tests {
 
         let cond = cp.dict.get("or").unwrap();
         assert_eq!(String::from("Or"), cond.borrow().condition_type());
-        let deps = cond.borrow().dependent_gates();
+        let deps = cond.borrow().dependent_conditions();
 
         assert_eq!(2, deps.len());
         assert_eq!(

--- a/src/messaging/condition_messages.rs
+++ b/src/messaging/condition_messages.rs
@@ -663,7 +663,7 @@ impl ConditionProcessor {
 
         ConditionProperties {
             cond_name: String::from(name),
-            type_name: c.borrow().gate_type(),
+            type_name: c.borrow().condition_type(),
             points: c.borrow().gate_points(),
             gates: d_names,
             parameters: c.borrow().dependent_parameters(),
@@ -997,7 +997,7 @@ mod cnd_processor_tests {
 
         let item = cp.dict.get("true-cond");
         assert!(item.is_some());
-        assert_eq!(String::from("True"), item.unwrap().borrow().gate_type());
+        assert_eq!(String::from("True"), item.unwrap().borrow().condition_type());
     }
     #[test]
     fn make_false_1() {
@@ -1011,7 +1011,7 @@ mod cnd_processor_tests {
 
         let item = cp.dict.get("false-cond");
         assert!(item.is_some());
-        assert_eq!(String::from("False"), item.unwrap().borrow().gate_type());
+        assert_eq!(String::from("False"), item.unwrap().borrow().condition_type());
     }
     #[test]
     fn make_not_1() {
@@ -1030,12 +1030,12 @@ mod cnd_processor_tests {
         let item = cp.dict.get("true");
         assert!(item.is_some());
         let cond = item.unwrap();
-        assert_eq!(String::from("Not"), cond.borrow().gate_type());
+        assert_eq!(String::from("Not"), cond.borrow().condition_type());
         let dep = cond.borrow().dependent_gates();
         assert_eq!(1, dep.len());
         assert_eq!(
             String::from("False"),
-            dep[0].upgrade().unwrap().borrow().gate_type()
+            dep[0].upgrade().unwrap().borrow().condition_type()
         );
     }
     #[test]
@@ -1057,17 +1057,17 @@ mod cnd_processor_tests {
         assert_eq!(ConditionReply::Created, rep);
 
         let cond = cp.dict.get("and").unwrap();
-        assert_eq!(String::from("And"), cond.borrow().gate_type());
+        assert_eq!(String::from("And"), cond.borrow().condition_type());
         let deps = cond.borrow().dependent_gates();
 
         assert_eq!(2, deps.len());
         assert_eq!(
             String::from("True"),
-            deps[0].upgrade().unwrap().borrow().gate_type()
+            deps[0].upgrade().unwrap().borrow().condition_type()
         );
         assert_eq!(
             String::from("False"),
-            deps[1].upgrade().unwrap().borrow().gate_type()
+            deps[1].upgrade().unwrap().borrow().condition_type()
         );
     }
     #[test]
@@ -1089,17 +1089,17 @@ mod cnd_processor_tests {
         assert_eq!(ConditionReply::Created, rep);
 
         let cond = cp.dict.get("or").unwrap();
-        assert_eq!(String::from("Or"), cond.borrow().gate_type());
+        assert_eq!(String::from("Or"), cond.borrow().condition_type());
         let deps = cond.borrow().dependent_gates();
 
         assert_eq!(2, deps.len());
         assert_eq!(
             String::from("True"),
-            deps[0].upgrade().unwrap().borrow().gate_type()
+            deps[0].upgrade().unwrap().borrow().condition_type()
         );
         assert_eq!(
             String::from("False"),
-            deps[1].upgrade().unwrap().borrow().gate_type()
+            deps[1].upgrade().unwrap().borrow().condition_type()
         );
     }
     #[test]
@@ -1113,7 +1113,7 @@ mod cnd_processor_tests {
         assert_eq!(ConditionReply::Created, rep);
 
         let cond = cp.dict.get("cut").unwrap();
-        assert_eq!("Cut", cond.borrow().gate_type());
+        assert_eq!("Cut", cond.borrow().condition_type());
         let pts = cond.borrow().gate_points();
         assert_eq!(2, pts.len());
         assert_eq!(100.0, pts[0].0);
@@ -1131,7 +1131,7 @@ mod cnd_processor_tests {
         assert_eq!(ConditionReply::Created, rep);
 
         let cond = cp.dict.get("band").unwrap();
-        assert_eq!(String::from("Band"), cond.borrow().gate_type());
+        assert_eq!(String::from("Band"), cond.borrow().condition_type());
         let pts = cond.borrow().gate_points();
         assert_eq!(condition_pts.len(), pts.len());
         for (i, p) in condition_pts.iter().enumerate() {
@@ -1151,7 +1151,7 @@ mod cnd_processor_tests {
         assert_eq!(ConditionReply::Created, rep);
 
         let cond = cp.dict.get("contour").unwrap();
-        assert_eq!(String::from("Contour"), cond.borrow().gate_type());
+        assert_eq!(String::from("Contour"), cond.borrow().condition_type());
         let pts = cond.borrow().gate_points();
         assert_eq!(condition_pts.len(), pts.len());
         for (i, p) in condition_pts.iter().enumerate() {
@@ -1171,7 +1171,7 @@ mod cnd_processor_tests {
         );
 
         let cond = cp.dict.get("acondition").unwrap();
-        assert_eq!("True", cond.borrow().gate_type());
+        assert_eq!("True", cond.borrow().condition_type());
         let cond = Rc::downgrade(cond); // Weak now
 
         // Replacing the condition should happen transparently
@@ -1183,7 +1183,7 @@ mod cnd_processor_tests {
         );
         assert_eq!(ConditionReply::Replaced, result);
 
-        assert_eq!("False", cond.upgrade().unwrap().borrow().gate_type());
+        assert_eq!("False", cond.upgrade().unwrap().borrow().condition_type());
     }
 
     // Other requests.
@@ -1341,7 +1341,7 @@ mod cnd_processor_tests {
 
         let item = cp.dict.get("test");
         assert!(item.is_some());
-        assert_eq!(String::from("MultiCut"), item.unwrap().borrow().gate_type());
+        assert_eq!(String::from("MultiCut"), item.unwrap().borrow().condition_type());
     }
     #[test]
     fn create_multi2_1() {
@@ -1363,7 +1363,7 @@ mod cnd_processor_tests {
         assert!(item.is_some());
         assert_eq!(
             String::from("MultiContour"),
-            item.unwrap().borrow().gate_type()
+            item.unwrap().borrow().condition_type()
         );
     }
     #[test]

--- a/src/messaging/condition_messages.rs
+++ b/src/messaging/condition_messages.rs
@@ -664,7 +664,7 @@ impl ConditionProcessor {
         ConditionProperties {
             cond_name: String::from(name),
             type_name: c.borrow().condition_type(),
-            points: c.borrow().gate_points(),
+            points: c.borrow().condition_points(),
             gates: d_names,
             parameters: c.borrow().dependent_parameters(),
         }
@@ -997,7 +997,10 @@ mod cnd_processor_tests {
 
         let item = cp.dict.get("true-cond");
         assert!(item.is_some());
-        assert_eq!(String::from("True"), item.unwrap().borrow().condition_type());
+        assert_eq!(
+            String::from("True"),
+            item.unwrap().borrow().condition_type()
+        );
     }
     #[test]
     fn make_false_1() {
@@ -1011,7 +1014,10 @@ mod cnd_processor_tests {
 
         let item = cp.dict.get("false-cond");
         assert!(item.is_some());
-        assert_eq!(String::from("False"), item.unwrap().borrow().condition_type());
+        assert_eq!(
+            String::from("False"),
+            item.unwrap().borrow().condition_type()
+        );
     }
     #[test]
     fn make_not_1() {
@@ -1114,7 +1120,7 @@ mod cnd_processor_tests {
 
         let cond = cp.dict.get("cut").unwrap();
         assert_eq!("Cut", cond.borrow().condition_type());
-        let pts = cond.borrow().gate_points();
+        let pts = cond.borrow().condition_points();
         assert_eq!(2, pts.len());
         assert_eq!(100.0, pts[0].0);
         assert_eq!(200.0, pts[1].0);
@@ -1132,7 +1138,7 @@ mod cnd_processor_tests {
 
         let cond = cp.dict.get("band").unwrap();
         assert_eq!(String::from("Band"), cond.borrow().condition_type());
-        let pts = cond.borrow().gate_points();
+        let pts = cond.borrow().condition_points();
         assert_eq!(condition_pts.len(), pts.len());
         for (i, p) in condition_pts.iter().enumerate() {
             assert_eq!(p.0, pts[i].0);
@@ -1152,7 +1158,7 @@ mod cnd_processor_tests {
 
         let cond = cp.dict.get("contour").unwrap();
         assert_eq!(String::from("Contour"), cond.borrow().condition_type());
-        let pts = cond.borrow().gate_points();
+        let pts = cond.borrow().condition_points();
         assert_eq!(condition_pts.len(), pts.len());
         for (i, p) in condition_pts.iter().enumerate() {
             assert_eq!(p.0, pts[i].0);
@@ -1341,7 +1347,10 @@ mod cnd_processor_tests {
 
         let item = cp.dict.get("test");
         assert!(item.is_some());
-        assert_eq!(String::from("MultiCut"), item.unwrap().borrow().condition_type());
+        assert_eq!(
+            String::from("MultiCut"),
+            item.unwrap().borrow().condition_type()
+        );
     }
     #[test]
     fn create_multi2_1() {

--- a/src/messaging/condition_messages.rs
+++ b/src/messaging/condition_messages.rs
@@ -654,7 +654,7 @@ impl ConditionProcessor {
         let dependencies = c.borrow().dependent_gates();
         let mut d_names = Vec::<String>::new();
         for d in dependencies.iter() {
-            if let Some(s) = gate_name_from_ref(&self.dict, d) {
+            if let Some(s) = condition_name_from_ref(&self.dict, d) {
                 d_names.push(s)
             } else {
                 d_names.push(String::from("-deleted-"));

--- a/src/messaging/spectrum_messages.rs
+++ b/src/messaging/spectrum_messages.rs
@@ -2,7 +2,7 @@
 //!  interfaces to spectra in the histogrammer.
 //!  Messages allow us to:
 //! *   Create and delete histograms of various sorts
-//! *   Apply gates to histograms.  These gates must be
+//! *   Apply conditions to histograms as gates.  These conditions must be
 //! conditions that are defined in a ConditionProcessor's dictionary.
 //! *   Ungate histograms.
 //! *   Clear the contents of individual or groups of histograms
@@ -1463,15 +1463,15 @@ impl SpectrumMessageClient {
             _ => Err(String::from("Unexpected server result for list request")),
         }
     }
-    /// Apply a gate to a spectrum:
+    /// Apply a condition to a spectrum:
     ///
     /// * spectrum -name of the spectrum.
-    /// * gate - name of the gate to apply.
+    /// * condition - name of the condition to apply.
     ///
     /// Retuns: SpectrumServerEmptyResult.
     ///
-    pub fn gate_spectrum(&self, spectrum: &str, gate: &str) -> SpectrumServerEmptyResult {
-        let reply = self.transact(Self::gate_request(spectrum, gate));
+    pub fn gate_spectrum(&self, spectrum: &str, condition: &str) -> SpectrumServerEmptyResult {
+        let reply = self.transact(Self::gate_request(spectrum, condition));
         if let SpectrumReply::Error(s) = reply {
             Err(s)
         } else {
@@ -3317,7 +3317,7 @@ mod spproc_tests {
         }
     }
 
-    // For our gate test we need some gates:
+    // For our gate test we need some conditions:
 
     fn make_some_gates(cd: &mut ConditionDictionary) {
         for i in 0..10 {
@@ -3376,7 +3376,7 @@ mod spproc_tests {
     }
     #[test]
     fn gate_2() {
-        // No such gate:
+        // No such condition:
         let mut to = make_test_objs();
         make_some_params(&mut to);
         make_some_gates(&mut to.conditions);

--- a/src/projections/mod.rs
+++ b/src/projections/mod.rs
@@ -240,13 +240,13 @@ pub fn make_projection_spectrum(
         status
     }
 }
-/// Create the gate appropriate to a projection spectcrum.  See
+/// Create the condition appropriate to a projection spectcrum.  See
 /// the description of project below for how this is derived.
 ///
 /// ### Parameters:
-///   *  gapi- Gate API instance reference.
+///   *  gapi- condition API instance reference.
 ///   *  dest_name -  destination spectrum name - used to generate
-/// the and gate if needed ("_dest_name_projection_gate_")
+/// the and condition if needed ("_dest_name_projection_gate_")
 ///   *  source_desc - References the description of the source spectrum.
 ///   *  contour - If Some the payload is the name of the AOI contour
 ///   *  snapshot - If true the specturm is a snapshot spectrum.
@@ -267,18 +267,18 @@ fn create_projection_gate(
     if source_desc.gate.is_none() && contour.is_none() {
         return None;
     }
-    // If there is a contour but no gate the contour rules:
+    // If there is a contour but no condition the contour rules:
 
     if contour.is_some() && source_desc.gate.is_none() {
         return Some(contour.clone().unwrap());
     }
 
-    // If there is no contour and a gate, that's the gate:
+    // If there is no contour and a condition, that's the condition:
 
     if contour.is_none() && source_desc.gate.is_some() {
         return Some(source_desc.gate.clone().unwrap());
     }
-    // If there is a contour and a gate we need to make and condition
+    // If there is a contour and a condition we need to make and condition
     // of the two of them.
     //
     if contour.is_some() && source_desc.gate.is_some() {
@@ -1750,7 +1750,7 @@ mod project_tests {
         {
             panic!("Failed to create contour : {}", s);
         }
-        // True gate we can put on the spectrum if we need to for testing:
+        // True condition we can put on the spectrum if we need to for testing:
 
         if let condition_messages::ConditionReply::Error(s) = capi.create_true_condition("true") {
             panic!("Failed to create true condition {}", s);
@@ -2366,7 +2366,7 @@ mod project_tests {
             );
         }
 
-        // See that the gate is correct:
+        // See that the condition is correct:
 
         match gapi.list_conditions("_proj_projection_gate_") {
             condition_messages::ConditionReply::Error(s) => assert!(false, "{}", s),
@@ -2384,7 +2384,7 @@ mod project_tests {
                     gate
                 );
             }
-            _ => assert!(false, "Unexpected return type from gate list"),
+            _ => assert!(false, "Unexpected return type from condition list"),
         };
 
         teardown(ch, jh);
@@ -2473,7 +2473,7 @@ mod project_tests {
             condition_messages::ConditionReply::Error(s) => assert!(false, "{}", s),
             condition_messages::ConditionReply::Listing(v) => {
                 assert_eq!(1, v.len());
-                let gate = v[0].clone();
+                let condition = v[0].clone();
                 assert_eq!(
                     condition_messages::ConditionProperties {
                         cond_name: String::from("_proj_projection_gate_"),
@@ -2482,10 +2482,10 @@ mod project_tests {
                         gates: vec![String::from("true"), String::from("contour")],
                         parameters: vec![]
                     },
-                    gate
+                    condition
                 );
             }
-            _ => assert!(false, "Unexpected return type from gate list"),
+            _ => assert!(false, "Unexpected return type from condition list"),
         }
         teardown(ch, jh);
     }

--- a/src/rest/apply.rs
+++ b/src/rest/apply.rs
@@ -1,5 +1,5 @@
 //!  Supplies the spectcl/apply domain of URIs.
-//!  This set of URIs has to do with the application of gates
+//!  This set of URIs has to do with the application of conditions
 //!  (conditions) to spectra and provides the following:
 //!
 //!  *  apply - applies a condition to a spectrum so that it can only
@@ -24,20 +24,20 @@ pub struct GateApplicationResponse {
     detail: Vec<(String, String)>,
 }
 
-///  Apply a gate to a spectrum.
+///  Apply a condition to a spectrum.
 ///  Query parameters are:
 ///
 /// *   gate (mandatory) - name of the condition
 /// *   spectrum (mandatory) - name of the spectrum to which
-/// to apply the gate.  The SpecTcl version of this only accepts a
+/// to apply the condition.  The SpecTcl version of this only accepts a
 /// single spectrum.   We accept any number of spectra, applying the
-/// gate to all.
+/// condition to all.
 ///
 /// On success a GateApplicationResponse is returned. With an empty
 /// array in the detail (status of course is _OK_).  On failure
 /// the message is "Failed to apply {gatename} to some spectra"
 /// and the detail is an array of the spectrum for which we could not
-/// apply the gate.
+/// apply the condition.
 ///
 #[get("/apply?<gate>&<spectrum>")]
 pub fn apply_gate(
@@ -189,7 +189,7 @@ mod apply_tests {
         let rocket = setup();
         let (chan, papi, bapi) = get_state(&rocket);
 
-        // No spectra so applying a gate will fail:
+        // No spectra so applying a condition will fail:
 
         let c = Client::tracked(rocket).unwrap();
         let r = c.get("/apply?gate=g&spectrum=spec");
@@ -209,7 +209,7 @@ mod apply_tests {
     }
     #[test]
     fn apply_gate_2() {
-        // need to make a parameter a spectrum and a gate to
+        // need to make a parameter a spectrum and a condition to
         // test success.
 
         let rocket = setup();
@@ -245,7 +245,7 @@ mod apply_tests {
         let r = c.get("/apply?gate=True&spectrum=test_spec");
         let reply = r.dispatch();
 
-        // Should get success and the gate should be applied:
+        // Should get success and the condition should be applied:
 
         let json = reply
             .into_json::<GateApplicationResponse>()
@@ -269,7 +269,7 @@ mod apply_tests {
         let rocket = setup();
         let (chan, papi, bapi) = get_state(&rocket);
 
-        // No spectra so applying a gate will fail:
+        // No spectra so applying a condition will fail:
 
         let c = Client::tracked(rocket).unwrap();
         let r = c.get("/list"); // no pattern/
@@ -287,7 +287,7 @@ mod apply_tests {
     fn apply_list_2() {
         // List no pattern but one listing.
 
-        // need to make a parameter a spectrum and a gate to
+        // need to make a parameter a spectrum and a condition to
         // test success.
 
         let rocket = setup();
@@ -317,7 +317,7 @@ mod apply_tests {
             .create_spectrum_1d("test_spec", "test", 0.0, 1024.0, 1024)
             .expect("making spectrum");
 
-        // apply the gate the easy way:
+        // apply the condition the easy way:
 
         spec_api
             .gate_spectrum("test_spec", "True")
@@ -343,7 +343,7 @@ mod apply_tests {
     fn apply_list_3() {
         // list pattern but does not match
 
-        // need to make a parameter a spectrum and a gate to
+        // need to make a parameter a spectrum and a condition to
         // test success.
 
         let rocket = setup();
@@ -373,7 +373,7 @@ mod apply_tests {
             .create_spectrum_1d("test_spec", "test", 0.0, 1024.0, 1024)
             .expect("making spectrum");
 
-        // apply the gate the easy way:
+        // apply the condition the easy way:
 
         spec_api
             .gate_spectrum("test_spec", "True")
@@ -397,7 +397,7 @@ mod apply_tests {
     fn apply_list_4() {
         // List with pattern which does match.
 
-        // need to make a parameter a spectrum and a gate to
+        // need to make a parameter a spectrum and a condition to
         // test success.
 
         let rocket = setup();
@@ -427,7 +427,7 @@ mod apply_tests {
             .create_spectrum_1d("test_spec", "test", 0.0, 1024.0, 1024)
             .expect("making spectrum");
 
-        // apply the gate the easy way:
+        // apply the condition the easy way:
 
         spec_api
             .gate_spectrum("test_spec", "True")
@@ -504,7 +504,7 @@ mod apply_tests {
             .create_spectrum_1d("test_spec", "test", 0.0, 1024.0, 1024)
             .expect("making spectrum");
 
-        // apply the gate the easy way:
+        // apply the condition the easy way:
 
         spec_api
             .gate_spectrum("test_spec", "True")

--- a/src/rest/apply.rs
+++ b/src/rest/apply.rs
@@ -98,7 +98,7 @@ pub fn apply_list(
         detail: Vec::new(),
     };
     for spectrum in listing {
-        let gate_name = if let Some(g) = spectrum.gate {
+        let condition_name = if let Some(g) = spectrum.gate {
             g
         } else {
             String::from("-none-")
@@ -106,7 +106,7 @@ pub fn apply_list(
 
         result.detail.push(Application {
             spectrum: spectrum.name,
-            gate: gate_name,
+            gate: condition_name,
         });
     }
     Json(result)

--- a/src/rest/filter.rs
+++ b/src/rest/filter.rs
@@ -8,7 +8,7 @@
 //!  
 //! *   Provide data in an already decoded format for speedy playback.
 //! *   Provide some subset of the  full data set (in SpecTcl this subset is
-//! defined by events that satisfy a gate and parameter list).
+//! defined by events that satisfy a condition and parameter list).
 //!
 //!  The first of these function is provided already by the fact that
 //! Rustogramer operates on data that is the output of the analysis
@@ -24,7 +24,7 @@
 //! *  delete - Would delete an existing filter.
 //! *  enable - would enable an existing filter to output data.
 //! *  disable - would disable an existing filter from outputting data.
-//! *  regate - would replace the gate on an existing filter that determines
+//! *  regate - would replace the condition on an existing filter that determines
 //! which subset it writes.
 //! *  file - Defines the file an existing filter writes data to.
 //! *  list - lists the set of filters that match an optional Glob pattern.
@@ -37,7 +37,7 @@ use rocket::serde::{json::Json, Deserialize, Serialize};
 /// are:
 ///
 /// *   name the name of the new filter.
-/// *   gate - the gate that will select the event the filter outputs.
+/// *   gate - the condition that will select the event the filter outputs.
 /// *   parameter - can repeat as many times as needed -the set of parameters
 /// that will be output.
 ///
@@ -83,12 +83,12 @@ pub fn disable() -> Json<GenericResponse> {
         "This is not SpecTcl",
     ))
 }
-/// regate - would specify a new gate be used to select the
+/// regate - would specify a new condition be used to select the
 /// set of events written by the filter.
 /// Query parameters;
 ///
 /// *   name - Name of the filter to modify.
-/// *   gate - gate to use to select output events
+/// *   gate - condition to use to select output events
 ///
 /// A GenericResponse is fine for this if it were implemented.
 ///

--- a/src/rest/gates.rs
+++ b/src/rest/gates.rs
@@ -5,7 +5,7 @@
 //! just objects that can be evaluated, as needed for each event
 //! which return a true or false value.  
 //!
-//! A condition can the gate (verb) a spectrum to determine which
+//! A condition can gate (verb) a spectrum to determine which
 //! events are allowed to increment it.
 //!
 //! A nasty concern is that the condition type names supported
@@ -13,7 +13,7 @@
 //! where those in SpecTcl (and therefore the type-names expected
 //! by REST clients) have simpler names like T, F, s, * (slice).
 //! it is therefore necessary to map from Rustogramer
-//! Gate types to SpecTcl gate types in this domain of URLs.
+//! condition types to SpecTcl gate types in this domain of URLs.
 
 use rocket::serde::{json::Json, Deserialize, Serialize};
 use rocket::State;
@@ -22,7 +22,7 @@ use super::*;
 
 use crate::messaging::condition_messages::{ConditionMessageClient, ConditionReply};
 
-// Private mappings between SpecTcl <-> Rustogramer gate types:
+// Private mappings between SpecTcl <-> Rustogramer condition types:
 // Note making a static hashmap is possible but requires unsafe to access.
 // Making the hashmap each time is possible but slower
 // so we'll just use if chains.
@@ -63,7 +63,7 @@ pub struct GateProperties {
     points: Vec<GatePoint>,
     low: f64,
     high: f64,
-    // value : u32            // Note Rustogrammer has no support for mask gates.
+    // value : u32            // Note Rustogrammer has no support for mask conditions.
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -106,7 +106,7 @@ fn marshall_points(p: &mut GateProperties, raw_pts: &Vec<(f64, f64)>) {
 }
 
 /// list conditions that match an optional _pattern_ string.
-/// the default pattern, if not supplied is "*" which match all gates.
+/// the default pattern, if not supplied is "*" which match all conditions.
 /// The resulting Json has a status field, which is *OK* on success
 /// and an error string on faiure, and a detail string which is an
 ///  array of structs that contain the following fields:
@@ -114,17 +114,17 @@ fn marshall_points(p: &mut GateProperties, raw_pts: &Vec<(f64, f64)>) {
 /// *   name - name of a condition.
 /// *   type - Condition type in SpecTcl notation e.g. a Rustogramer *BAND*
 /// has type *b*
-/// *   gates - Possibly empty array of dependent gate names.  This will only
+/// *   gates - Possibly empty array of dependent condition names.  This will only
 /// be nonempty if the type string is one of _+_, _-_, or _*_
 /// *   parameters - Possibly empty array of parameters that must be
 /// present in order for the condition to be evaluated (does not include
 /// parameters in dependent conditions).  This will only be nonempty for
 /// types: _s_, _b_ or _c_ though see low, high below for _s_ conditions.
-/// *   low - The low limit of a _s_ gate - this is just the x coordinate of
+/// *   low - The low limit of a _s_ condition - this is just the x coordinate of
 /// the first point in points.
-/// *   high - the high limit of a _s_ gate - this is just the x coordinate
+/// *   high - the high limit of a _s_ condition - this is just the x coordinate
 /// of the second point in points.
-/// *   points for 2-d gates an array of {x,y} objects.
+/// *   points for 2-d conditions an array of {x,y} objects.
 ///
 /// The simplistic manner in which each GateProperties struct is filled in
 /// provides for the presence of data in fields where the SpecTcl REST
@@ -170,7 +170,7 @@ pub fn list_gates(
             r
         }
         ConditionReply::Error(s) => ListReply {
-            status: format!("Failed to list gates matching '{}' : {}", pat, s),
+            status: format!("Failed to list conditions matching '{}' : {}", pat, s),
             detail: Vec::<GateProperties>::new(),
         },
         _ => ListReply {
@@ -183,9 +183,9 @@ pub fn list_gates(
 //--------------------------------------------------------------------
 // Delete condition
 
-/// Delete a gate.
+/// Delete a condition.
 ///
-/// Requires the name of the gate as a query parameter.
+/// Requires the name of the condition as a query parameter.
 ///
 /// * Successful response has status = "OK" and detail an empty string.
 /// * Failure respons has status something like "Failed to delete conditions {}"
@@ -209,7 +209,7 @@ pub fn delete_gate(name: String, state: &State<SharedHistogramChannel>) -> Json<
 //--------------------------------------------------------------
 // Edit/create conditions:
 
-// Validate the query parameters needed to make a slice gate and extract them
+// Validate the query parameters needed to make a slice condition and extract them
 //
 fn validate_slice_parameters(
     parameter: OptionalStringVec,
@@ -219,7 +219,7 @@ fn validate_slice_parameters(
 ) -> Result<(u32, f64, f64), String> {
     if parameter.is_none() {
         return Err(String::from(
-            "The parameter query parameter is required for slice gates",
+            "The parameter query parameter is required for slice conditions",
         ));
     }
     let parameter = parameter.unwrap();
@@ -229,7 +229,7 @@ fn validate_slice_parameters(
     let parameter_name = &parameter[0];
     if low.is_none() || high.is_none() {
         return Err(String::from(
-            "Both the low and high query parameters are requried for slice gates",
+            "Both the low and high query parameters are requried for slice conditions",
         ));
     }
     let low = low.unwrap();
@@ -253,22 +253,22 @@ fn validate_2d_parameters(
 ) -> Result<TwodParameters, String> {
     if xpname.is_none() {
         return Err(String::from(
-            "xparameter is a mandatory query parameter for this gate type",
+            "xparameter is a mandatory query parameter for this condition type",
         ));
     }
     if ypname.is_none() {
         return Err(String::from(
-            "yparameter is a mandatory query parameter for this gate type",
+            "yparameter is a mandatory query parameter for this condition type",
         ));
     }
     if xcoord.is_none() {
         return Err(String::from(
-            "xcoord is a mandatory query parameter for this gate type",
+            "xcoord is a mandatory query parameter for this condition type",
         ));
     }
     if ycoord.is_none() {
         return Err(String::from(
-            "ycoord is a mandatory query parameter for this gate type",
+            "ycoord is a mandatory query parameter for this condition type",
         ));
     }
     // unwrap the parametesr from their options:
@@ -345,25 +345,33 @@ fn validate_multi2_parameters(
     parameter: OptionalStringVec,
     xcoords: OptionalF64Vec,
     ycoords: OptionalF64Vec,
-    state: &State<SharedHistogramChannel>
+    state: &State<SharedHistogramChannel>,
 ) -> Result<(Vec<u32>, Vec<(f64, f64)>), String> {
     // THere must be parameers, x and y coordinates:
 
     if parameter.is_none() {
-        return Err(String::from("Parameters are required for a multi parameter contour"));
+        return Err(String::from(
+            "Parameters are required for a multi parameter contour",
+        ));
     }
     let parameter = parameter.unwrap();
 
     if xcoords.is_none() {
-        return Err(String::from("xcoords are required for multi parameter contours"));
+        return Err(String::from(
+            "xcoords are required for multi parameter contours",
+        ));
     }
     if ycoords.is_none() {
-        return Err(String::from("ycoords are required for multi parameters contous"));
+        return Err(String::from(
+            "ycoords are required for multi parameters contous",
+        ));
     }
     let x = xcoords.unwrap();
     let y = ycoords.unwrap();
     if x.len() != y.len() {
-        return Err(String::from("There must be the same number of x and y coordinates."))
+        return Err(String::from(
+            "There must be the same number of x and y coordinates.",
+        ));
     }
     // Marshall the points:
 
@@ -385,29 +393,29 @@ fn validate_multi2_parameters(
     Ok((ids, pts))
 }
 ///
-/// Create/edit a gate.  Note that creating a new gate and editing
-/// an existing gate.  If we 'edit' a new gate the gate is created
-/// and saved in the condition dictionary.  If we 'edit' an existing gate,
+/// Create/edit a condition.  Note that creating a new condition and editing
+/// an existing condition are the same.  If we 'edit' a new condition the condition is created
+/// and saved in the condition dictionary.  If we 'edit' an existing condition,
 /// the condition replaces the old one and the server side
 /// return value indicates this.
 /// The required query parameters are:
 ///
-/// *   name - the name of the gate to create/edit.
-/// *   type - The SpecTcl type of the gate to create/edit.
+/// *   name - the name of the condition to create/edit.
+/// *   type - The SpecTcl type of the condition to create/edit.
 ///
-/// The other parameters required depend on the gate type:
+/// The other parameters required depend on the condition type:
 ///
-/// *  T, F gates require nothing else.
-/// *  + - * gates require gate - a list of gates the gate depends on.
-///These gates must already be defined.
+/// *  T, F conditions require nothing else.
+/// *  + - * conditions require condition - a list of conditions the condition depends on.
+///These conditions must already be defined.
 /// *  c, b require:
-///     -   xparameter, yparameter - the parameters the gate is set on.
-///     -   xcoord, ycoord - the x/y coordinates of the points that make up the gate.
+///     -   xparameter, yparameter - the parameters the condition is set on.
+///     -   xcoord, ycoord - the x/y coordinates of the points that make up the condition.
 /// * s requires:
 ///     - parameter for the parameter the condition is set on.
 ///     - low - low limit of the slice.
 ///     - high - high limit of the slice.
-/// Other gate types are not supported.
+/// Other condition types are not supported.
 ///
 /// The response is a GenericResponse.  On success,
 ///
@@ -441,52 +449,54 @@ pub fn edit_gate(
         "T" => api.create_true_condition(&name),
         "F" => api.create_false_condition(&name),
         "-" => {
-            // There must be exactly one gate:
+            // There must be exactly one condition:
 
             if let Some(gate) = gate {
                 if gate.len() == 1 {
                     api.create_not_condition(&name, &gate[0])
                 } else {
                     ConditionReply::Error(String::from(
-                        "Not gates can have at most one dependent gate",
+                        "Not conditions can have at most one dependent condition",
                     ))
                 }
             } else {
                 ConditionReply::Error(String::from(
-                    "gate is a required query parameter for not gates",
+                    "gate is a required query parameter for not conditions",
                 ))
             }
         }
         "*" => {
-            // There must be at least one gate:
+            // There must be at least one condition:
 
             if let Some(gate) = gate {
                 if !gate.is_empty() {
                     api.create_and_condition(&name, &gate)
                 } else {
                     ConditionReply::Error(String::from(
-                        "And gates require at least one dependent gate",
+                        "And conditions require at least one dependent condition",
                     ))
                 }
             } else {
                 ConditionReply::Error(String::from(
-                    "And gates require the 'gate' query parameters",
+                    "And conditions require the 'gate' query parameters",
                 ))
             }
         }
         "+" => {
-            // There must be at least one gate:
+            // There must be at least one condition:
 
-            if let Some(gate) = gate {
-                if !gate.is_empty() {
-                    api.create_or_condition(&name, &gate)
+            if let Some(condition) = gate {
+                if !condition.is_empty() {
+                    api.create_or_condition(&name, &condition)
                 } else {
                     ConditionReply::Error(String::from(
-                        "Or gates require at least one dependent gate",
+                        "Or conditions require at least one dependent condition",
                     ))
                 }
             } else {
-                ConditionReply::Error(String::from("Or gates require the 'gate' query parameters"))
+                ConditionReply::Error(String::from(
+                    "Or conditions require the 'gate' query parameters",
+                ))
             }
         }
         "s" => {
@@ -513,17 +523,17 @@ pub fn edit_gate(
             Err(s) => ConditionReply::Error(s),
             Ok((ids, points)) => api.create_multicontour_condition(&name, &ids, &points),
         },
-        _ => ConditionReply::Error(format!("Unsupported gate type: {}", r#type)),
+        _ => ConditionReply::Error(format!("Unsupported condition type: {}", r#type)),
     };
 
     let reply = match raw_result {
         ConditionReply::Created => GenericResponse::ok("Created"),
         ConditionReply::Replaced => GenericResponse::ok("Replaced"),
         ConditionReply::Error(s) => {
-            GenericResponse::err(&format!("Could not create/edit gate {}", name), &s)
+            GenericResponse::err(&format!("Could not create/edit condition {}", name), &s)
         }
         _ => GenericResponse::err(
-            &format!("Could not create/edit gate {}", name),
+            &format!("Could not create/edit condition {}", name),
             "Unexpected respones type from server",
         ),
     };
@@ -566,7 +576,7 @@ mod gate_tests {
         rest_common::get_state(r)
     }
     // Create parameters p1, p2
-    // which will be used to create gates that need parameters.
+    // which will be used to create conditions that need parameters.
     //
     fn make_test_objects(c: &mpsc::Sender<messaging::Request>) {
         let api = parameter_messages::ParameterMessageClient::new(c);
@@ -597,7 +607,7 @@ mod gate_tests {
     }
     #[test]
     fn list_2() {
-        // Make a T gate and make sure the right properties are present.
+        // Make a T condition and make sure the right properties are present.
 
         let rocket = setup();
         let (c, papi, bapi) = get_state(&rocket);
@@ -628,7 +638,7 @@ mod gate_tests {
     }
     #[test]
     fn list_3() {
-        // Make an F gate ...
+        // Make an F condition ...
 
         let rocket = setup();
         let (c, papi, bapi) = get_state(&rocket);
@@ -872,7 +882,7 @@ mod gate_tests {
     }
     #[test]
     fn list_10() {
-        // Make a multislice gate and see that it is listed:
+        // Make a multislice condition and see that it is listed:
 
         let rocket = setup();
         let (c, papi, bapi) = get_state(&rocket);
@@ -913,7 +923,7 @@ mod gate_tests {
     }
     #[test]
     fn list_11() {
-        // List a gc (MultiContour):
+        // List a gc (MultiContour) condition:
 
         let rocket = setup();
         let (c, papi, bapi) = get_state(&rocket);
@@ -955,11 +965,11 @@ mod gate_tests {
 
         teardown(c, &papi, &bapi);
     }
-    // Gate deletion:
+    // condition deletion:
 
     #[test]
     fn delete_1() {
-        // Delete a nonexistent gate:
+        // Delete a nonexistent condition:
 
         let rocket = setup();
         let (c, papi, bapi) = get_state(&rocket);
@@ -997,13 +1007,13 @@ mod gate_tests {
         teardown(c, &papi, &bapi);
     }
 
-    // Note that edit is used to both create and modify gates.
-    // Except for the last test we'll be creating gates.
-    // The final edit_n test will modify an existing gate.
+    // Note that edit is used to both create and modify conditions.
+    // Except for the last test we'll be creating conditions.
+    // The final edit_n test will modify an existing condition.
 
     #[test]
     fn edit_1() {
-        // Create True gate:
+        // Create True condition:
 
         let rocket = setup();
         let (c, papi, bapi) = get_state(&rocket);
@@ -1036,7 +1046,7 @@ mod gate_tests {
     }
     #[test]
     fn edit_2() {
-        // create a False gate:
+        // create a False condition:
 
         let rocket = setup();
         let (c, papi, bapi) = get_state(&rocket);
@@ -1068,18 +1078,18 @@ mod gate_tests {
 
         teardown(c, &papi, &bapi);
     }
-    // Test not gates and error scenarios.  Note we assume that
-    // dependent gate existence is checked by the tests in condition_messages.
+    // Test not conditions and error scenarios.  Note we assume that
+    // dependent condition existence is checked by the tests in condition_messages.
 
     #[test]
     fn edit_3() {
-        // make  a not gate:
+        // make  a not condition:
 
         let rocket = setup();
         let (c, papi, bapi) = get_state(&rocket);
 
         let api = condition_messages::ConditionMessageClient::new(&c);
-        api.create_true_condition("true"); // dependent gate:
+        api.create_true_condition("true"); // dependent condition:
 
         let client = Client::tracked(rocket).expect("Creating client");
         let req = client.get("/edit?name=not&type=-&gate=true");
@@ -1111,7 +1121,7 @@ mod gate_tests {
     }
     #[test]
     fn edit_4() {
-        // fail creation of not gate -- need a dependent gate:
+        // fail creation of not condition -- need a dependent condition:
 
         let rocket = setup();
         let (c, papi, bapi) = get_state(&rocket);
@@ -1122,9 +1132,9 @@ mod gate_tests {
             .into_json::<GenericResponse>()
             .expect("Parsing JSON");
 
-        assert_eq!("Could not create/edit gate not", reply.status);
+        assert_eq!("Could not create/edit condition not", reply.status);
         assert_eq!(
-            "gate is a required query parameter for not gates",
+            "gate is a required query parameter for not conditions",
             reply.detail
         );
 
@@ -1132,7 +1142,7 @@ mod gate_tests {
     }
     #[test]
     fn edit_5() {
-        // Fail creation of not gate - must have only 1 dependent gate:
+        // Fail creation of not condition - must have only 1 dependent condition:
 
         let rocket = setup();
         let (c, papi, bapi) = get_state(&rocket);
@@ -1143,15 +1153,15 @@ mod gate_tests {
             .into_json::<GenericResponse>()
             .expect("Parsing JSON");
 
-        assert_eq!("Could not create/edit gate not", reply.status);
+        assert_eq!("Could not create/edit condition not", reply.status);
         assert_eq!(
-            "Not gates can have at most one dependent gate",
+            "Not conditions can have at most one dependent condition",
             reply.detail
         );
 
         teardown(c, &papi, &bapi);
     }
-    // Test and gates and error scenarios.
+    // Test and conditions and error scenarios.
 
     #[test]
     fn edit_6() {
@@ -1160,10 +1170,10 @@ mod gate_tests {
         let rocket = setup();
         let (c, papi, bapi) = get_state(&rocket);
 
-        // Make dependent gates:
+        // Make dependent conditions:
 
         let api = condition_messages::ConditionMessageClient::new(&c);
-        api.create_true_condition("true"); // dependent gate:
+        api.create_true_condition("true"); // dependent condition:
         api.create_false_condition("false");
 
         let client = Client::tracked(rocket).expect("Creating client");
@@ -1194,7 +1204,7 @@ mod gate_tests {
     }
     #[test]
     fn edit_7() {
-        // no dependent gates provided.
+        // no dependent conditions provided.
 
         let rocket = setup();
         let (c, papi, bapi) = get_state(&rocket);
@@ -1206,15 +1216,15 @@ mod gate_tests {
             .into_json::<GenericResponse>()
             .expect("Parsing JSON");
 
-        assert_eq!("Could not create/edit gate and", reply.status);
+        assert_eq!("Could not create/edit condition and", reply.status);
         assert_eq!(
-            "And gates require the 'gate' query parameters",
+            "And conditions require the 'gate' query parameters",
             reply.detail
         );
 
         teardown(c, &papi, &bapi);
     }
-    // Tests for Or gates. Note the literal + is a stand-in for
+    // Tests for Or conditions. Note the literal + is a stand-in for
     // ' ' so we need to use the escap %2B instead.
 
     #[test]
@@ -1224,10 +1234,10 @@ mod gate_tests {
         let rocket = setup();
         let (c, papi, bapi) = get_state(&rocket);
 
-        // Make dependent gates:
+        // Make dependent conditions:
 
         let api = condition_messages::ConditionMessageClient::new(&c);
-        api.create_true_condition("true"); // dependent gate:
+        api.create_true_condition("true"); // dependent condition:
         api.create_false_condition("false");
 
         let client = Client::tracked(rocket).expect("Creating client");
@@ -1270,12 +1280,15 @@ mod gate_tests {
             .into_json::<GenericResponse>()
             .expect("Parsing JSON");
 
-        assert_eq!("Could not create/edit gate or", reply.status);
-        assert_eq!("Or gates require the 'gate' query parameters", reply.detail);
+        assert_eq!("Could not create/edit condition or", reply.status);
+        assert_eq!(
+            "Or conditions require the 'gate' query parameters",
+            reply.detail
+        );
 
         teardown(c, &papi, &bapi);
     }
-    // Slice gate tests:
+    // Slice condition tests:
 
     #[test]
     fn edit_10() {
@@ -1295,7 +1308,7 @@ mod gate_tests {
         assert_eq!("OK", reply.status);
         assert_eq!("Created", reply.detail);
 
-        // check the gate:
+        // check the condition:
 
         let api = condition_messages::ConditionMessageClient::new(&c);
         let listing = api.list_conditions("*");
@@ -1327,9 +1340,9 @@ mod gate_tests {
             .into_json::<GenericResponse>()
             .expect("Parsing JSON");
 
-        assert_eq!("Could not create/edit gate slice", reply.status);
+        assert_eq!("Could not create/edit condition slice", reply.status);
         assert_eq!(
-            "The parameter query parameter is required for slice gates",
+            "The parameter query parameter is required for slice conditions",
             reply.detail
         );
         teardown(c, &papi, &bapi);
@@ -1348,9 +1361,9 @@ mod gate_tests {
             .into_json::<GenericResponse>()
             .expect("Parsing JSON");
 
-        assert_eq!("Could not create/edit gate slice", reply.status);
+        assert_eq!("Could not create/edit condition slice", reply.status);
         assert_eq!(
-            "Both the low and high query parameters are requried for slice gates",
+            "Both the low and high query parameters are requried for slice conditions",
             reply.detail
         );
         teardown(c, &papi, &bapi);
@@ -1367,9 +1380,9 @@ mod gate_tests {
             .into_json::<GenericResponse>()
             .expect("Parsing JSON");
 
-        assert_eq!("Could not create/edit gate slice", reply.status);
+        assert_eq!("Could not create/edit condition slice", reply.status);
         assert_eq!(
-            "Both the low and high query parameters are requried for slice gates",
+            "Both the low and high query parameters are requried for slice conditions",
             reply.detail
         );
         teardown(c, &papi, &bapi);
@@ -1392,7 +1405,7 @@ mod gate_tests {
 
         assert_eq!("OK", reply.status);
 
-        // Check the gate was proprly made:
+        // Check the condition was proprly made:
 
         let api = condition_messages::ConditionMessageClient::new(&c);
         let l = api.list_conditions("*");
@@ -1429,9 +1442,9 @@ mod gate_tests {
             .into_json::<GenericResponse>()
             .expect("Parsing json");
 
-        assert_eq!("Could not create/edit gate band", reply.status);
+        assert_eq!("Could not create/edit condition band", reply.status);
         assert_eq!(
-            "xparameter is a mandatory query parameter for this gate type",
+            "xparameter is a mandatory query parameter for this condition type",
             reply.detail
         );
 
@@ -1452,9 +1465,9 @@ mod gate_tests {
             .into_json::<GenericResponse>()
             .expect("Parsing json");
 
-        assert_eq!("Could not create/edit gate band", reply.status);
+        assert_eq!("Could not create/edit condition band", reply.status);
         assert_eq!(
-            "yparameter is a mandatory query parameter for this gate type",
+            "yparameter is a mandatory query parameter for this condition type",
             reply.detail
         );
 
@@ -1476,9 +1489,9 @@ mod gate_tests {
             .into_json::<GenericResponse>()
             .expect("Parsing json");
 
-        assert_eq!("Could not create/edit gate band", reply.status);
+        assert_eq!("Could not create/edit condition band", reply.status);
         assert_eq!(
-            "xcoord is a mandatory query parameter for this gate type",
+            "xcoord is a mandatory query parameter for this condition type",
             reply.detail
         );
 
@@ -1500,9 +1513,9 @@ mod gate_tests {
             .into_json::<GenericResponse>()
             .expect("Parsing json");
 
-        assert_eq!("Could not create/edit gate band", reply.status);
+        assert_eq!("Could not create/edit condition band", reply.status);
         assert_eq!(
-            "ycoord is a mandatory query parameter for this gate type",
+            "ycoord is a mandatory query parameter for this condition type",
             reply.detail
         );
 
@@ -1525,7 +1538,7 @@ mod gate_tests {
             .into_json::<GenericResponse>()
             .expect("Parsing json");
 
-        assert_eq!("Could not create/edit gate band", reply.status);
+        assert_eq!("Could not create/edit condition band", reply.status);
         assert_eq!(
             "xcoord array has 2 entries but ycoord array has 1 -they must be the same length",
             reply.detail
@@ -1549,7 +1562,7 @@ mod gate_tests {
             .into_json::<GenericResponse>()
             .expect("Parsing json");
 
-        assert_eq!("Could not create/edit gate band", reply.status);
+        assert_eq!("Could not create/edit condition band", reply.status);
 
         teardown(c, &papi, &bapi);
     }
@@ -1613,7 +1626,7 @@ mod gate_tests {
             .into_json::<GenericResponse>()
             .expect("parsing json");
 
-        assert_eq!("Could not create/edit gate contour", reply.status);
+        assert_eq!("Could not create/edit condition contour", reply.status);
 
         teardown(c, &papi, &bapi);
     }
@@ -1707,7 +1720,7 @@ mod gate_tests {
             .into_json::<GenericResponse>()
             .expect("Parsing JSON");
 
-        assert_eq!("Could not create/edit gate test", reply.status);
+        assert_eq!("Could not create/edit condition test", reply.status);
 
         teardown(c, &papi, &bapi);
     }
@@ -1727,7 +1740,7 @@ mod gate_tests {
             .into_json::<GenericResponse>()
             .expect("Parsing JSON");
 
-        assert_eq!("Could not create/edit gate test", reply.status);
+        assert_eq!("Could not create/edit condition test", reply.status);
 
         teardown(c, &papi, &bapi);
     }
@@ -1746,7 +1759,7 @@ mod gate_tests {
             .into_json::<GenericResponse>()
             .expect("Parsing JSON");
 
-        assert_eq!("Could not create/edit gate test", reply.status);
+        assert_eq!("Could not create/edit condition test", reply.status);
 
         teardown(c, &papi, &bapi);
     }
@@ -1765,7 +1778,7 @@ mod gate_tests {
             .into_json::<GenericResponse>()
             .expect("Parsing JSON");
 
-        assert_eq!("Could not create/edit gate test", reply.status);
+        assert_eq!("Could not create/edit condition test", reply.status);
 
         teardown(c, &papi, &bapi);
     }

--- a/src/rest/integrate.rs
+++ b/src/rest/integrate.rs
@@ -52,7 +52,7 @@ fn generate_aoi(
         // gate if Some, must be a cut.  We'll return either AreaOfInterest::All
         // or AreaOfInterest::Oned.
 
-        if let Some(gate_name) = gate {
+        if let Some(condition_name) = gate {
             if low.is_some() | high.is_some() {
                 return Err(String::from(
                     "1d spectra can only have either a gate name or limits",
@@ -60,10 +60,10 @@ fn generate_aoi(
             } else {
                 // get the gate information.
 
-                match api.list_conditions(&gate_name) {
+                match api.list_conditions(&condition_name) {
                     condition_messages::ConditionReply::Listing(l) => {
                         if l.len() != 1 {
-                            return Err(format!("{} either is a non-existent condition or is pattern that has more than one match", gate_name));
+                            return Err(format!("{} either is a non-existent condition or is pattern that has more than one match", condition_name));
                         }
                         let condition = l[0].clone();
                         if condition.type_name == "Cut" {
@@ -74,20 +74,20 @@ fn generate_aoi(
                         } else {
                             return Err(format!(
                                 "{} is not a Cut and must be for 1-d integrations",
-                                gate_name
+                                condition_name
                             ));
                         }
                     }
                     condition_messages::ConditionReply::Error(s) => {
                         return Err(format!(
                             "Failed to get information about gate {}: {}",
-                            gate_name, s
+                            condition_name, s
                         ));
                     }
                     _ => {
                         return Err(format!(
                             "Unexpected response from getting condition properties for {}",
-                            gate_name
+                            condition_name
                         ));
                     }
                 };
@@ -107,19 +107,19 @@ fn generate_aoi(
     } else {
         // 2d we're allowed to have gate or x/y coordinates of a contour.
 
-        if let Some(gate_name) = gate {
+        if let Some(condition_name) = gate {
             if xcoord.is_some() || ycoord.is_some() {
                 return Err(String::from("For a 2d spectrum only the gate _OR_ the AOI coordinates are allowed, not both"));
             }
             // Get condition information - must be a contour and we
             // then reconstruct it to make it a 2d area of interest:
 
-            match api.list_conditions(&gate_name) {
+            match api.list_conditions(&condition_name) {
                 condition_messages::ConditionReply::Listing(l) => {
                     if l.len() != 1 {
                         return Err(format!(
                             "{} either is a nonexistent condition or is a non-unique pattern",
-                            gate_name
+                            condition_name
                         ));
                     }
 
@@ -130,7 +130,7 @@ fn generate_aoi(
                         Err(s) => {
                             return Err(format!(
                                 "Failed to construct a contour from {} : {}",
-                                gate_name, s
+                                condition_name, s
                             ));
                         }
                     }
@@ -139,13 +139,13 @@ fn generate_aoi(
                 condition_messages::ConditionReply::Error(s) => {
                     return Err(format!(
                         "Unable to get {} condition description: {}",
-                        gate_name, s
+                        condition_name, s
                     ));
                 }
                 _ => {
                     return Err(format!(
                         "Unexpected responses getting description of condition {}",
-                        gate_name
+                        condition_name
                     ));
                 }
             }

--- a/src/rest/integrate.rs
+++ b/src/rest/integrate.rs
@@ -86,7 +86,7 @@ fn generate_aoi(
                     }
                     _ => {
                         return Err(format!(
-                            "Unexpected response from getting gate properties for {}",
+                            "Unexpected response from getting condition properties for {}",
                             gate_name
                         ));
                     }
@@ -111,7 +111,7 @@ fn generate_aoi(
             if xcoord.is_some() || ycoord.is_some() {
                 return Err(String::from("For a 2d spectrum only the gate _OR_ the AOI coordinates are allowed, not both"));
             }
-            // Get gate information - must be a contour and we
+            // Get condition information - must be a contour and we
             // then reconstruct it to make it a 2d area of interest:
 
             match api.list_conditions(&gate_name) {
@@ -194,16 +194,16 @@ fn generate_aoi(
 /// query parameters depending on the type of integration being performed
 ///
 /// * spectrum (mandatory) - The spectrum to be integrated.
-/// * gate (optional) - If the gate can appear drawn on the spectrum,
-/// the integration will be over the interior of the gate.
+/// * gate (optional) - If the condition can appear drawn on the spectrum,
+/// the integration will be over the interior of the condition.
 /// * low - If the spectrum is one dimensional and the integration is
-/// not in a gate this is the low limit of the range of channels
+/// not in a condition this is the low limit of the range of channels
 /// over which to integrate.
 /// * high - if the spectrum is 1d the high limit over which to integerate.
 /// * xcoord - If the
-/// integration is not in a gate and in a 2d spectrum, these are
+/// integration is not in a condition and in a 2d spectrum, these are
 /// the X coordinates of a contour within which an integration is performed.
-/// * ycoord - if the integrations is not in a gate and  in a 2d spectrum,
+/// * ycoord - if the integrations is not in a condition and  in a 2d spectrum,
 /// these are the set of y coordinates of points that describe the
 /// contour within which the integration will be done.
 ///
@@ -479,7 +479,7 @@ mod integrate_tests {
     #[test]
     fn error_2() {
         // Spectrum is ok but condition name is nonexistent
-        // gate name.
+        // condition name.
 
         let r = setup();
         let (chan, p, b) = getstate(&r);
@@ -497,7 +497,7 @@ mod integrate_tests {
     }
     #[test]
     fn error_3() {
-        // Condition exists but is not a legal integration gate:
+        // Condition exists but is not a legal integration condition:
 
         let r = setup();
         let (chan, p, b) = getstate(&r);
@@ -533,7 +533,7 @@ mod integrate_tests {
     }
     #[test]
     fn error_5() {
-        // Same as error 4 but 2d spectrum with cut gate:
+        // Same as error 4 but 2d spectrum with cut condition:
 
         let r = setup();
         let (chan, p, b) = getstate(&r);
@@ -551,7 +551,7 @@ mod integrate_tests {
     }
     #[test]
     fn error_6() {
-        // oned integration can have gate or low/high but not both
+        // oned integration can have condition or low/high but not both
 
         let r = setup();
         let (chan, p, b) = getstate(&r);
@@ -586,7 +586,7 @@ mod integrate_tests {
     }
     #[test]
     fn oned_1() {
-        // Integrate 1d with no gate
+        // Integrate 1d with no condition
 
         let r = setup();
         let (chan, p, b) = getstate(&r);
@@ -712,7 +712,7 @@ mod integrate_tests {
     }
     #[test]
     fn twod_1() {
-        // 2d with no gate:
+        // 2d with no condition:
 
         let r = setup();
         let (chan, p, b) = getstate(&r);

--- a/src/rest/project.rs
+++ b/src/rest/project.rs
@@ -210,7 +210,7 @@ mod project_rest_tests {
             }
             _ => panic!("Failed to create contour"),
         };
-        // A simple gate that can be applied to the spectrum if desired.
+        // A simple condition that can be applied to the spectrum if desired.
 
         match capi.create_cut_condition("cut", 2, 100.0, 200.0) {
             condition_messages::ConditionReply::Created => {}
@@ -492,7 +492,7 @@ mod project_rest_tests {
 
         teardown(hch, &papi, &bapi);
     }
-    // Projetions within a contour gate the resulting spectrum on
+    // Projetions within a contour condition the resulting spectrum on
     // the contour - if there are no other things that infulence.
 
     #[test]

--- a/src/rest/spectrum.rs
+++ b/src/rest/spectrum.rs
@@ -160,7 +160,7 @@ fn list_to_detail(l: Vec<SpectrumProperties>) -> Vec<SpectrumDescription> {
 /// *   yaxis - same as xaxis but for the Y axis specification, if any.
 /// *   chantype -- the data type of each channel in the spectrum.
 /// in rustogramer this is hardcoded to _f64_
-/// *    gate if not _null_ thisi s the name of the conditions that
+/// *    gate if not _null_ this is the name of the conditions that
 /// is applied as a gate to the spectrum.
 ///
 /// Note:  SpecTcl and Rustogrammer don't support knowing

--- a/src/rest/spectrumio.rs
+++ b/src/rest/spectrumio.rs
@@ -600,8 +600,8 @@ fn enter_spectra(
     let parameter_api =
         parameter_messages::ParameterMessageClient::new(&hg_chan.inner().lock().unwrap());
     let mut parameters = make_parameter_set(&parameter_api)?;
-    // snapshots require a _snapshot_condition_ gate.  No harm to
-    // make it again so just undonditionally make it:
+    // snapshots require a _snapshot_condition_ gate.  This is a False
+    // condition.  No harm to make it again so just unconditionally make it:
     if as_snapshot {
         let condition_api =
             condition_messages::ConditionMessageClient::new(&hg_chan.inner().lock().unwrap());
@@ -613,7 +613,7 @@ fn enter_spectra(
 
         make_parameters(&s.definition, &mut parameters, &parameter_api)?;
 
-        // Create the spectrum and, if necessary gate it on our False gate.
+        // Create the spectrum and, if necessary gate it on our False condition.
 
         let actual_name = enter_spectrum(&s.definition, replace, &spectrum_api)?;
         if as_snapshot {
@@ -677,7 +677,7 @@ fn fix_json_bins(input: Vec<SpectrumFileData>) -> Vec<SpectrumFileData> {
 /// *  filename - (mandatory) path to the file to read.
 /// *  format - (mandatory) spectrum format.  json and ascii are supported in
 /// a case blind way.
-/// *  snapshot - (optional) if true (default is yes), a _False_ gate is
+/// *  snapshot - (optional) if true (default is yes), a _False_ condition is
 /// set on the spectrum that's read in.  If necessary a _False_ condition named
 /// _snapshot_condition_ is created.  If snapshot is false, then the spectrum
 /// will increment if new data is processed.
@@ -1513,7 +1513,7 @@ mod swrite_tests {
         let copy = sapi.list_spectra("oned_0").expect("Listing oned_0");
 
         // Spectrum descriptions must match execpt for the gate
-        // which is the snapshot gate since we did not turn that off.
+        // which is the snapshot condition since we did not turn that off.
 
         assert_eq!(1, original.len());
         let o = &original[0];
@@ -1615,8 +1615,8 @@ mod swrite_tests {
         let original = sapi.list_spectra("oned").expect("Listing oned");
         let copy = sapi.list_spectra("oned_0").expect("Listing oned_0");
 
-        // Spectrum descriptions must match execpt for the gate
-        // which is the snapshot gate since we did not turn that off.
+        // Spectrum descriptions must match except for the gate
+        // which is the snapshot condition since we did not turn that off.
 
         assert_eq!(1, original.len());
         let o = &original[0];

--- a/src/rest/traces.rs
+++ b/src/rest/traces.rs
@@ -108,7 +108,7 @@ pub struct TraceGetResponse {
 ///      *  The name of the spectrum added or deleted.
 ///  * gate - Each list contains:
 ///      *  The trace reason:  "add", "delete", "changed"
-///      *  The name of the gate that was affected.
+///      *  The name of the condition that was affected.
 ///  * binding - Each list contains:
 ///      *  The trace reason which is one of "add" (bind), "remove" (unbind)
 ///      *  Then name of the affected spectrum.

--- a/src/rest/unimplemented.rs
+++ b/src/rest/unimplemented.rs
@@ -4,16 +4,9 @@
 //!  
 //!  They include, in no particular order:
 //!
-//! *   Mirroring of the shared memory - that is actually
-//! Scheduled for version 0.2
 //! *   pipeline management - There is no analysis pipeline in Rustogramer,
 //! the analysis pipeline as concieved of for SpecTcl is external and
 //! provide Rustogramer with pre-decoded data.
-//! *   projection - I'm not that sure about when/how to do that. Arguably,
-//! This is something that could be done in a displayer.   It could also
-//! Be argued that a projection is really just a 1-d spectrum the user could
-//! define which, may or may not be gated on another spectrum.  After all,
-//! that's how they are implemented in SpecTcl.
 //! *   psuedo - Any computed parameters are done in the external analysis
 //! pipeline and, therefore are not supported in Rustogramer.  Note
 //! that the psuedo feature of SpecTcl itself is seldom used, more normally

--- a/src/spectra/mod.rs
+++ b/src/spectra/mod.rs
@@ -99,9 +99,9 @@ impl SpectrumGate {
         SpectrumGate { gate: None }
     }
     /// Set a new gate:
-    /// If the gate does not exist Err is returned.
+    /// If the condition does not exist Err is returned.
     /// Otherwise self.gate is Some(name, downgraded gate container).
-    /// Note that if the gate cannot be found, the prior
+    /// Note that if the condition cannot be found, the prior
     /// value remains.
     ///
     pub fn set_gate(&mut self, name: &str, dict: &ConditionDictionary) -> Result<(), String> {
@@ -122,9 +122,9 @@ impl SpectrumGate {
     /// Evaluate the gate for an event  The following cases and results
     /// are considered
     /// *   self.gate.is_none() - the spectrum is ungated, true is returned.
-    /// *   upgrading the gate to an RC gives None - the underlying gate
+    /// *   upgrading the gate to an RC gives None - the underlying condition
     ///     was deleted:
-    ///     The gate has been deleted from the dict, we're now ungated
+    ///     The condition has been deleted from the dict, we're now ungated
     ///     return true.
     /// *   Upgrading gave Some - evaluate the resulting gate.
     ///
@@ -687,7 +687,7 @@ mod gate_tests {
     }
     #[test]
     fn spgate_ungate1() {
-        // can ungate an ugate - still none:
+        // can ungate an ungated - still none:
 
         let mut g = SpectrumGate::new();
         g.ungate();
@@ -719,7 +719,7 @@ mod gate_tests {
     // - Gated gives the result of the gate.
     //   *  True gate.
     //   *  False gate.
-    // - Gated but the gate was deleted is always true...and ungates us.
+    // - Gated but the condition was deleted is always true...and ungates us.
     //
     #[test]
     fn spgate_check1() {
@@ -781,7 +781,7 @@ mod gate_tests {
         let e = FlatEvent::new();
         assert!(!g.check(&e));
 
-        // Now kill off the gate from the dict:
+        // Now kill off the condition from the dict:
         // The {} ensures the container is dropped.
         {
             dict.remove(&String::from("false"))

--- a/src/spectra/multi1d.rs
+++ b/src/spectra/multi1d.rs
@@ -7,6 +7,8 @@
 //!  Multi1d spectra can have a gate as well which can conditionalize when
 //!  the spectrum is incremented.  
 //!
+//!  Multi1d spectra can also be folded.
+//!
 //!  Axis defaults are determined in a manner identical to the way
 //!  axis defaults for the y axis of a summary spectrum are determined.
 //!  
@@ -17,6 +19,7 @@ use std::collections::HashSet;
 
 ///
 /// *  applied_gate - is the gate that can conditionalize increments.
+/// *  applied_fold - is the fold, if any, applied to the spectrum.
 /// *  name         - is the name of the spectrum.
 /// *  histogram    - is the actual histogram object.
 /// *  param_names  - are the names of the parameters we're defined on.
@@ -644,7 +647,7 @@ mod fold_tests {
     }
     #[test]
     fn pid_2() {
-        // If folded but nothing is in the gate again, we get all parameters
+        // If folded but nothing is in the condition again, we get all parameters
         // in the fold back (due to the intersection).
 
         let mut pdict = ParameterDictionary::new();
@@ -670,9 +673,9 @@ mod fold_tests {
     }
     #[test]
     fn pid_3() {
-        // If there are parameters in the gate, they are omited from get_param_ids
+        // If there are parameters in the fold, they are omited from get_param_ids
 
-        // If folded but nothing is in the gate again, we get all parameters
+        // If folded but nothing is in the fold again, we get all parameters
         // in the fold back (due to the intersection).
 
         let mut pdict = ParameterDictionary::new();

--- a/src/spectra/multi2d.rs
+++ b/src/spectra/multi2d.rs
@@ -16,6 +16,10 @@
 //! As with any spectrum a condition can be applied as a gate on
 //! incrementing the spectrum.  Gated spectra will only be incremented
 //! for events for which the gating condition is true.
+//!
+//! Multi2d spectra can also have a fold applied.  If a fold is applied,
+//! Only the parameter pairs that don't make the fold condition true
+//! are allowed to increment the spectrum.
 
 use super::*;
 

--- a/src/spectra/pgamma.rs
+++ b/src/spectra/pgamma.rs
@@ -14,6 +14,10 @@
 //!  of the spectrum.  That is the condition, applied as the gate must
 //!  be true for the event to be eligible to increment the spectrum.
 //!
+//!  Furthermore a fold can be applied to the spectrum, in which case every
+//!  parameter pair which satisfies the fold condition is removed from the
+//!  increment.
+//!
 //!  Default axis specification are derived indpendently from the
 //!  default axis specification fo the X and Y parameter sets.
 //!  The algorithm to choose from among the specification is the same
@@ -675,7 +679,7 @@ mod pgamma_tests {
     }
     #[test]
     fn incr_2() {
-        // gated on a True gate:
+        // gated on a True condition:
 
         let dict = make_params(10, Some((0.0, 1024.0)), Some(1024));
         let xp = vec![

--- a/src/spectra/summary.rs
+++ b/src/spectra/summary.rs
@@ -493,8 +493,6 @@ mod summary_tests {
     fn incr_3() {
         // Add False gate and the increments don't happen.
 
-        // add a T gate - should still increment:
-
         let mut pd = ParameterDictionary::new();
         let mut names = Vec::<String>::new();
         for i in 0..10 {

--- a/src/spectra/twodsum.rs
+++ b/src/spectra/twodsum.rs
@@ -2,7 +2,7 @@
 //!  be the sum of several two d spectra with the same gate applied.
 //!
 //!  The spectrum is defined over an arbitrary set of x/y parameter
-//!  pairs.  If the applied gate is satisfied, the spectrum is incremented
+//!  pairs.  The spectrum is incremented
 //!  for each of those pairs which have a value in the event.
 //!
 //!  Suppose, for example, the spectrum is defined on the following (x,y)


### PR DESCRIPTION
Straighten out inconsistencies in the use of the term  'gate' vs. 'condition'  
A 'condition' is something that can be checked for true/false on an event by event basis.  A gate is a condition applied to a spectrum which,  for events for which the condition are true, allow the spectrum to be incremented.

SpecTcl uses the term 'gate' interchangeably with what Rustogramer calls a condition and some of that carried over into comments and function naming.

Issue #120