### PR TITLE
Issue #152 - Make selected tab more visible.

### DIFF
--- a/restclients/Python/Gui.py
+++ b/restclients/Python/Gui.py
@@ -74,8 +74,71 @@ def setup_menubar(win, client):
     
     help_menu = menubar.addMenu("&Help")
     help_menu_object = HelpMenu.Help(help_menu)
-    
 
+# Per issue #152 style the tabs so the selected one is more visible
+#  see:   
+# #  https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qtabwidget-and-qtabbar
+# and:
+#  https://doc.qt.io/qtforpython-6/overviews/stylesheet-examples.html
+def setTabStyle(app):
+    app.setStyleSheet('''
+QTabWidget::pane { /* The tab widget frame */
+    border-top: 2px solid #C2C7CB;
+}
+
+QTabWidget::tab-bar {
+    left: 5px; /* move to the right by 5px */
+}
+
+/* Style the tab using the tab sub-control. Note that
+    it reads QTabBar _not_ QTabWidget */
+QTabBar::tab {
+    background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
+                                stop: 0 #E1E1E1, stop: 0.4 #DDDDDD,
+                                stop: 0.5 #D8D8D8, stop: 1.0 #D3D3D3);
+    border: 2px solid #C4C4C3;
+    border-bottom-color: #C2C7CB; /* same as the pane color */
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+    min-width: 8ex;
+    padding: 2px;
+}
+
+QTabBar::tab:selected, QTabBar::tab:hover {
+    background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
+                                stop: 0 #fafafa, stop: 0.4 #f4f4f4,
+                                stop: 0.5 #e7e7e7, stop: 1.0 #fafafa);
+}
+
+QTabBar::tab:selected {
+    border-color: #9B9B9B;
+    border-bottom-color: #C2C7CB; /* same as pane color */
+}
+
+QTabBar::tab:!selected {
+    margin-top: 2px; /* make non-selected tabs look smaller */
+}
+
+/* make use of negative margins for overlapping tabs */
+QTabBar::tab:selected {
+    /* expand/overlap to the left and right by 4px */
+    margin-left: -4px;
+    margin-right: -4px;
+}
+
+QTabBar::tab:first:selected {
+    margin-left: 0; /* the first selected tab has nothing to overlap with on the left */
+}
+
+QTabBar::tab:last:selected {
+    margin-right: 0; /* the last selected tab has nothing to overlap with on the right */
+}
+
+QTabBar::tab:only-one {
+    margin: 0; /* if there is only one tab, we don't want overlapping margins */
+}
+''')
+    
 PORTMAN_PORT=30000
 
 parsed_args = argparse.ArgumentParser(
@@ -111,6 +174,10 @@ gatelist.common_condition_model.load(client)
 
 app = QApplication(sys.argv)
 main = QMainWindow()
+
+# Style sheet to make the selected tabs stand out more:
+
+setTabStyle(app)
 
 tabs = QTabWidget()
 spectrum_view = spectra.SpectrumWidget()


### PR DESCRIPTION
This is done via styling the tabbed widget.
See https://doc.qt.io/qtforpython-6/overviews/stylesheet-examples.html for how to apply styling in pyqt and:

https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qtabwidget-and-qtabbar

for the actual style sheet used.